### PR TITLE
Clarify which key is used for the Napalm port

### DIFF
--- a/nornir/plugins/tasks/connections/napalm_connection.py
+++ b/nornir/plugins/tasks/connections/napalm_connection.py
@@ -8,7 +8,7 @@ def napalm_connection(task=None, timeout=60, optional_args=None):
 
     Arguments:
         timeout (int, optional): defaults to 60
-        optional_args (dict, optional): defaults to ``{"port": task.host["network_api_port"]}``
+        optional_args (dict, optional): defaults to ``{"port": task.host["nornir_network_api_port"]}``
 
     Inventory:
         napalm_options: maps directly to ``optional_args`` when establishing the connection

--- a/nornir/plugins/tasks/connections/napalm_connection.py
+++ b/nornir/plugins/tasks/connections/napalm_connection.py
@@ -8,7 +8,7 @@ def napalm_connection(task=None, timeout=60, optional_args=None):
 
     Arguments:
         timeout (int, optional): defaults to 60
-        optional_args (dict, optional): defaults to ``{"port": task.host["nornir_network_api_port"]}``
+        optional_args (dict, optional): defaults to `{"port": task.host["nornir_network_api_port"]}`
 
     Inventory:
         napalm_options: maps directly to ``optional_args`` when establishing the connection


### PR DESCRIPTION
The current docstring is wrong and can cause confusion.

Another solution would be to point to `task.host.network_api_port` but before we have a specific section in the documentation which talks about how these are connected I think it's better to point to the key as in this PR.