### PR TITLE
add to_dict function so the inventory is serializable

### DIFF
--- a/nornir/core/__init__.py
+++ b/nornir/core/__init__.py
@@ -58,6 +58,10 @@ class Data(object):
         """Reset failed hosts and make all hosts available for future tasks."""
         self.failed_hosts = set()
 
+    def to_dict(self):
+        """ Return a dictionary representing the object. """
+        return self.__dict__
+
 
 class Nornir(object):
     """
@@ -248,6 +252,10 @@ class Nornir(object):
         else:
             self.data.failed_hosts.update(result.failed_hosts.keys())
         return result
+
+    def to_dict(self):
+        """ Return a dictionary representing the object. """
+        return {"data": self.data.to_dict(), "inventory": self.inventory.to_dict()}
 
 
 def InitNornir(config_file="", dry_run=False, **kwargs):

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -106,6 +106,10 @@ class Host(object):
         """
         return self._resolve_data().items()
 
+    def to_dict(self):
+        """ Return a dictionary representing the object. """
+        return self.data
+
     def has_parent_group(self, group):
         """Retuns whether the object is a child of the :obj:`Group` ``group``"""
         for g in self.groups:
@@ -363,3 +367,10 @@ class Inventory(object):
 
         for g in self.groups.values():
             g.nornir = value
+
+    def to_dict(self):
+        """ Return a dictionary representing the object. """
+        return {
+            "hosts": {k: v.to_dict() for k, v in self.hosts.items()},
+            "groups": {k: v.to_dict() for k, v in self.groups.items()},
+        }

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -370,7 +370,8 @@ class Inventory(object):
 
     def to_dict(self):
         """ Return a dictionary representing the object. """
+        groups = {k: v.to_dict() for k, v in self.groups.items()}
+        groups["defaults"] = self.defaults
         return {
-            "hosts": {k: v.to_dict() for k, v in self.hosts.items()},
-            "groups": {k: v.to_dict() for k, v in self.groups.items()},
+            "hosts": {k: v.to_dict() for k, v in self.hosts.items()}, "groups": groups
         }

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -204,3 +204,35 @@ class Test(object):
         assert not inventory.hosts["dev1.group_1"].has_parent_group(
             inventory.groups["group_2"]
         )
+
+    def test_to_dict(self):
+        expected = {
+            "hosts": {
+                "dev1.group_1": {
+                    "name": "dev1.group_1",
+                    "groups": ["group_1"],
+                    "my_var": "comes_from_dev1.group_1",
+                    "www_server": "nginx",
+                    "role": "www",
+                    "nornir_ssh_port": 65001,
+                    "nornir_nos": "eos",
+                },
+                "dev3.group_2": {
+                    "name": "dev3.group_2",
+                    "groups": ["group_2"],
+                    "www_server": "apache",
+                    "role": "www",
+                    "nornir_ssh_port": 65003,
+                    "nornir_network_api_port": 12443,
+                    "nornir_os": "linux",
+                    "nornir_nos": "mock",
+                },
+            },
+            "groups": {
+                "group_1": {
+                    "name": "group_1", "my_var": "comes_from_group_1", "site": "site1"
+                },
+                "group_2": {"name": "group_2", "site": "site2"},
+            },
+        }
+        assert inventory.filter(role="www").to_dict() == expected

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -229,6 +229,7 @@ class Test(object):
                 },
             },
             "groups": {
+                "defaults": {},
                 "group_1": {
                     "name": "group_1", "my_var": "comes_from_group_1", "site": "site1"
                 },


### PR DESCRIPTION
To discuss, might be nice if we can dump with a `to_dict` an inventory object and make it load back into the same object. I think we should bother about doing it as a `dict` instead of as a `json` or any other format as each one of them have a different mechanism to deal with custom objects and we should assume they should work.

Basically what I'd like to do here is make sure that we can do something equivalent to `my_inv == Inventory(my_inv.to_dict())`