### PR TITLE
Group membership filter

### DIFF
--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -338,24 +338,19 @@ class Inventory(object):
         if filter_func:
             filtered = {n: h for n, h in self.hosts.items() if filter_func(h, **kwargs)}
         else:
+            filtered = self.hosts
             if 'group_member' in kwargs:
                 group_member = kwargs['group_member']
                 filtered = {
                     n: h
-                    for n, h in self.hosts.items()
+                    for n, h in filtered.items()
                     if h.has_parent_group(self.groups[group_member])
                 }
-                if len(kwargs) > 1:
-                    filtered = {
-                        n: h
-                        for n, h in filtered.items()
-                        if all(h.get(k) == v for k, v in kwargs.items() if k != 'group_member')
-                    }
-            else:
-                filtered = {
+
+            filtered = {
                     n: h
-                    for n, h in self.hosts.items()
-                    if all(h.get(k) == v for k, v in kwargs.items())
+                    for n, h in filtered.items()
+                    if all(h.get(k) == v for k, v in kwargs.items() if k != 'group_member')
                 }
 
         return Inventory(hosts=filtered, groups=self.groups, nornir=self.nornir)

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -338,11 +338,26 @@ class Inventory(object):
         if filter_func:
             filtered = {n: h for n, h in self.hosts.items() if filter_func(h, **kwargs)}
         else:
-            filtered = {
-                n: h
-                for n, h in self.hosts.items()
-                if all(h.get(k) == v for k, v in kwargs.items())
-            }
+            if 'group_member' in kwargs:
+                group_member = kwargs['group_member']
+                filtered = {
+                    n: h
+                    for n, h in self.hosts.items()
+                    if h.has_parent_group(self.groups[group_member])
+                }
+                if len(kwargs) > 1:
+                    filtered = {
+                        n: h
+                        for n, h in filtered.items()
+                        if all(h.get(k) == v for k, v in kwargs.items() if k != 'group_member')
+                    }
+            else:
+                filtered = {
+                    n: h
+                    for n, h in self.hosts.items()
+                    if all(h.get(k) == v for k, v in kwargs.items())
+                }
+
         return Inventory(hosts=filtered, groups=self.groups, nornir=self.nornir)
 
     def __len__(self):

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -339,8 +339,8 @@ class Inventory(object):
             filtered = {n: h for n, h in self.hosts.items() if filter_func(h, **kwargs)}
         else:
             filtered = self.hosts
-            if 'group_member' in kwargs:
-                group_member = kwargs['group_member']
+            if "group_member" in kwargs:
+                group_member = kwargs["group_member"]
                 filtered = {
                     n: h
                     for n, h in filtered.items()
@@ -348,10 +348,10 @@ class Inventory(object):
                 }
 
             filtered = {
-                    n: h
-                    for n, h in filtered.items()
-                    if all(h.get(k) == v for k, v in kwargs.items() if k != 'group_member')
-                }
+                n: h
+                for n, h in filtered.items()
+                if all(h.get(k) == v for k, v in kwargs.items() if k != "group_member")
+            }
 
         return Inventory(hosts=filtered, groups=self.groups, nornir=self.nornir)
 

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -174,7 +174,11 @@ class Test(object):
         assert group_member == ["dev1.group_1"]
 
         group_member = sorted(
-            list(inventory.filter(group_member="group_2").filter(group_member="group_alt").hosts.keys())
+            list(
+                inventory.filter(group_member="group_2").filter(
+                    group_member="group_alt"
+                ).hosts.keys()
+            )
         )
         assert group_member == ["dev4.group_2"]
 

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -158,6 +158,26 @@ class Test(object):
         )
         assert www_site1 == ["dev1.group_1"]
 
+        group_member = sorted(
+            list(inventory.filter(group_member="group_2").hosts.keys())
+        )
+        assert group_member == ["dev3.group_2", "dev4.group_2"]
+
+        group_member = sorted(
+            list(inventory.filter(group_member="group_alt").hosts.keys())
+        )
+        assert group_member == ["dev4.group_2"]
+
+        group_member = sorted(
+            list(inventory.filter(role="www", group_member="group_1").hosts.keys())
+        )
+        assert group_member == ["dev1.group_1"]
+
+        group_member = sorted(
+            list(inventory.filter(group_member="group_2").filter(group_member="group_alt").hosts.keys())
+        )
+        assert group_member == ["dev4.group_2"]
+
     def test_filtering_func(self):
         long_names = sorted(
             list(

--- a/tests/inventory_data/groups.yaml
+++ b/tests/inventory_data/groups.yaml
@@ -12,3 +12,6 @@ group_1:
 
 group_2:
     site: site2
+
+group_alt:
+    site: alt

--- a/tests/inventory_data/hosts.yaml
+++ b/tests/inventory_data/hosts.yaml
@@ -30,6 +30,7 @@ dev3.group_2:
 dev4.group_2:
     groups:
         - group_2
+        - group_alt
     my_var: comes_from_dev4.group_2
     role: db
     nornir_ssh_port: 65004


### PR DESCRIPTION
Here is the code I used for initial testing against the changes specified in the PR.

```
from nornir.core import InitNornir
from nornir.plugins.tasks.networking import netmiko_send_command
from nornir.plugins.functions.text import print_result
from nornir.core.inventory import Inventory

norn = InitNornir()
junos_hosts = norn.filter(group_member='juniper')

result = junos_hosts.run(
     netmiko_send_command,
     num_workers=60,
     command_string="show interfaces terse"
)
 
print_result(result)
```

The hosts.yaml entry intentionally has multiple groups so you can't just do:

```
junos_hosts = norn.filter(groups=['juniper'])
```


I think this is probably a common enough pattern (host belonging to multiple groups) and wanting to filter by group that we probably should have some pretty simple solution for it.