### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6
+RUN set -x && \
+	pip install nornir
+VOLUME [ "/nornir" ]
+WORKDIR "/nornir"
+ENTRYPOINT [ "/usr/local/bin/python" ]
+#usage:
+# from inside your nornir base directory run: docker run -it --rm -v `pwd`:/nornir nornir:latest get_facts.py


### PR DESCRIPTION
This Dockerfile allows executing your python scripts from inside a
docker container.
It requires your scripts to be mounted to the volume at /nornir as this
is set as the working directory.

Usage: # docker run -it --rm -v `pwd`:/nornir nornir:latest get_facts.py

Signed-off-by: Jeroen Simonetti <jeroen@simonetti.nl>