### PR TITLE
WIP - thread safety

### DIFF
--- a/nornir/core/__init__.py
+++ b/nornir/core/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 import sys
+import threading
 from multiprocessing.dummy import Pool
 
 from nornir.core.configuration import Config
@@ -179,12 +180,15 @@ class Nornir(object):
             result[host.name] = Task(task, **kwargs).start(host, self)
         return result
 
-    def _run_parallel(self, task, hosts, num_workers, **kwargs):
+    def _run_parallel(self, task, hosts, num_workers, thread_safe, **kwargs):
         result = AggregatedResult(kwargs.get("name") or task.__name__)
+
+        lock = threading.Lock() if thread_safe else None
 
         pool = Pool(processes=num_workers)
         result_pool = [
-            pool.apply_async(Task(task, **kwargs).start, args=(h, self)) for h in hosts
+            pool.apply_async(Task(task, lock=lock, **kwargs).start, args=(h, self))
+            for h in hosts
         ]
         pool.close()
         pool.join()
@@ -201,6 +205,7 @@ class Nornir(object):
         raise_on_error=None,
         on_good=True,
         on_failed=False,
+        thread_safe=False,
         **kwargs
     ):
         """
@@ -244,7 +249,9 @@ class Nornir(object):
         if num_workers == 1:
             result = self._run_serial(task, run_on, **kwargs)
         else:
-            result = self._run_parallel(task, run_on, num_workers, **kwargs)
+            result = self._run_parallel(
+                task, run_on, num_workers, thread_safe, **kwargs
+            )
 
         raise_on_error = raise_on_error if raise_on_error is not None else self.config.raise_on_error  # noqa
         if raise_on_error:

--- a/nornir/core/__init__.py
+++ b/nornir/core/__init__.py
@@ -1,7 +1,6 @@
 import logging
 import logging.config
 import sys
-import threading
 from multiprocessing.dummy import Pool
 
 from nornir.core.configuration import Config

--- a/nornir/core/__init__.py
+++ b/nornir/core/__init__.py
@@ -183,11 +183,11 @@ class Nornir(object):
     def _run_parallel(self, task, hosts, num_workers, thread_safe, **kwargs):
         result = AggregatedResult(kwargs.get("name") or task.__name__)
 
-        lock = threading.Lock() if thread_safe else None
-
         pool = Pool(processes=num_workers)
         result_pool = [
-            pool.apply_async(Task(task, lock=lock, **kwargs).start, args=(h, self))
+            pool.apply_async(
+                Task(task, thread_safe=thread_safe, **kwargs).start, args=(h, self)
+            )
             for h in hosts
         ]
         pool.close()

--- a/tests/core/test_multithreading.py
+++ b/tests/core/test_multithreading.py
@@ -14,6 +14,10 @@ def blocking_task(task, wait):
     time.sleep(wait)
 
 
+def group_task_thread_safety(task, wait):
+    task.run(blocking_task, wait=wait, thread_safe=True)
+
+
 def failing_task_simple(task):
     raise Exception(task.host.name)
 
@@ -42,6 +46,22 @@ class Test(object):
     def test_blocking_task_multithreading(self, nornir):
         t1 = datetime.datetime.now()
         nornir.run(blocking_task, wait=2, num_workers=NUM_WORKERS)
+        t2 = datetime.datetime.now()
+        delta = t2 - t1
+        assert delta.seconds == 2, delta
+
+    def test_blocking_task_multithreading_thread_safety(self, nornir):
+        # this should behave like test_block_task_single_thread
+        t1 = datetime.datetime.now()
+        nornir.run(blocking_task, wait=0.5, num_workers=NUM_WORKERS, thread_safe=True)
+        t2 = datetime.datetime.now()
+        delta = t2 - t1
+        assert delta.seconds == 2, delta
+
+    def test_blocking_subtask_multithreading_thread_safety(self, nornir):
+        # this should behave like test_block_task_single_thread
+        t1 = datetime.datetime.now()
+        nornir.run(group_task_thread_safety, wait=0.5, num_workers=NUM_WORKERS)
         t2 = datetime.datetime.now()
         delta = t2 - t1
         assert delta.seconds == 2, delta

--- a/tests/core/test_multithreading.py
+++ b/tests/core/test_multithreading.py
@@ -1,7 +1,7 @@
 import datetime
 import time
 
-from nornir.core.exceptions import NornirExecutionError, CommandError
+from nornir.core.exceptions import CommandError, NornirExecutionError
 from nornir.plugins.tasks import commands
 
 import pytest


### PR DESCRIPTION
The idea is that now you can run tasks passing `thread_safe=True` and make sure that those tasks run only one at a time. This is useful if only one of your grouped tasks needs to be thread-safe.

I want to extend this to the `print_result` function so you can print them safely even during subtasks.

If we all agree we want this I will update the docstrings and probably add a note in the execution model.