### PR TITLE
Updating Netmiko plugins to disconnect at the end of a session.

### DIFF
--- a/nornir/plugins/tasks/networking/netmiko_send_command.py
+++ b/nornir/plugins/tasks/networking/netmiko_send_command.py
@@ -19,4 +19,8 @@ def netmiko_send_command(task, command_string, use_timing=False, **kwargs):
         result = net_connect.send_command_timing(command_string, **kwargs)
     else:
         result = net_connect.send_command(command_string, **kwargs)
+
+    # Cleanup the open net_connect connection, prevents stale sessions when using ssh ProxyCommand
+    net_connect.disconnect()
+
     return Result(host=task.host, result=result)

--- a/nornir/plugins/tasks/networking/netmiko_send_config.py
+++ b/nornir/plugins/tasks/networking/netmiko_send_config.py
@@ -23,4 +23,7 @@ def netmiko_send_config(task, config_commands=None, config_file=None, **kwargs):
     else:
         raise ValueError("Must specify either config_commands or config_file")
 
+    # Cleanup the open net_connect connection, prevents stale sessions when using ssh ProxyCommand
+    net_connect.disconnect()
+
     return Result(host=task.host, result=result, changed=True)


### PR DESCRIPTION
When utilizing SSH ProxyCommand to jump through a bastion/jump box, the lack of utilizing `disconnect()` leaves dozens of stale sessions open on the bastion.

This becomes a resource constraint/problem at scale, and starts to make Paramiko choke and die with similar stack traces to the below:

```    'Error reading SSH protocol banner' + str(e)
paramiko.ssh_exception.SSHException: Error reading SSH protocol banner
```

(Sensitive data redacted below)
```    raise ProxyCommandFailure(' '.join(self.cmd), e.strerror)
paramiko.ssh_exception.ProxyCommandFailure: ('ssh USER@BASTION nc IPADDRESS 22', 'Broken pipe')
```

If I force `.disconnect()` on each connection, it largely eliminates these problems.