### PR TITLE
Remove deprecated ruamel.yaml API calls

### DIFF
--- a/nornir/core/configuration.py
+++ b/nornir/core/configuration.py
@@ -93,7 +93,8 @@ class Config(object):
     def __init__(self, config_file=None, **kwargs):
         if config_file:
             with open(config_file, "r") as f:
-                data = ruamel.yaml.safe_load(f.read()) or {}
+                yml = ruamel.yaml.YAML()
+                data = yml.load(f) or {}
         else:
             data = {}
 

--- a/nornir/plugins/inventory/ansible.py
+++ b/nornir/plugins/inventory/ansible.py
@@ -104,7 +104,7 @@ class AnsibleParser(object):
 
         with open(filepath, "r") as f:
             logger.debug("AnsibleInventory: reading var file: {}".format(filepath))
-            yml = ruamel.yaml.YAML(typ="rt", pure=True)
+            yml = ruamel.yaml.YAML()
             return yml.load(f)
 
     @staticmethod
@@ -206,8 +206,8 @@ class INIParser(AnsibleParser):
 class YAMLParser(AnsibleParser):
     def load_hosts_file(self) -> None:
         with open(self.hostsfile, "r") as f:
-            yml = ruamel.yaml.YAML(typ="rt", pure=True)
-            self.original_data = cast(AnsibleGroupsDict, yml.load(f.read()))
+            yml = ruamel.yaml.YAML()
+            self.original_data = cast(AnsibleGroupsDict, yml.load(f))
 
 
 def parse(hostsfile: str) -> Tuple[HostsDict, GroupsDict]:

--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -122,13 +122,14 @@ class SimpleInventory(Inventory):
         group_file: str = "groups.yaml",
         **kwargs: Any
     ) -> None:
+        yml = ruamel.yaml.YAML()
         with open(host_file, "r") as f:
-            hosts: HostsDict = ruamel.yaml.safe_load(f.read())
+            hosts: HostsDict = yml.load(f)
 
         if group_file:
             if os.path.exists(group_file):
                 with open(group_file, "r") as f:
-                    groups: GroupsDict = ruamel.yaml.safe_load(f.read())
+                    groups: GroupsDict = yml.load(f)
             else:
                 logging.warning("{}: doesn't exist".format(group_file))
                 groups = {}

--- a/nornir/plugins/tasks/data/load_yaml.py
+++ b/nornir/plugins/tasks/data/load_yaml.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from nornir.core.task import Result, Task
 
 import ruamel.yaml
@@ -23,9 +21,8 @@ def load_yaml(task: Task, file: str):
         Result object with the following attributes set:
           * result (``dict``): dictionary with the contents of the file
     """
-    kwargs: Dict[str, str] = {}
     with open(file, "r") as f:
-        yml = ruamel.yaml.YAML(pure=True, **kwargs)
-        data = yml.load(f.read())
+        yml = ruamel.yaml.YAML(pure=True)
+        data = yml.load(f)
 
     return Result(host=task.host, result=data)

--- a/tests/plugins/inventory/test_ansible.py
+++ b/tests/plugins/inventory/test_ansible.py
@@ -3,8 +3,8 @@ import os
 from nornir.plugins.inventory import ansible
 
 import pytest
-
 import ruamel.yaml
+from ruamel.yaml.scanner import ScannerError
 
 
 BASE_PATH = os.path.join(os.path.dirname(__file__), "ansible")
@@ -12,18 +12,19 @@ BASE_PATH = os.path.join(os.path.dirname(__file__), "ansible")
 
 def save(hosts, groups, hosts_file, groups_file):
     yml = ruamel.yaml.YAML(typ="safe", pure=True)
+    yml.default_flow_style = False
     with open(hosts_file, "w+") as f:
-        f.write(yml.dump(hosts, default_flow_style=False))
+        f.write(yml.dump(hosts))
     with open(groups_file, "w+") as f:
-        f.write(yml.dump(groups, default_flow_style=False))
+        f.write(yml.dump(groups))
 
 
 def read(hosts_file, groups_file):
     yml = ruamel.yaml.YAML(typ="safe")
     with open(hosts_file, "r") as f:
-        hosts = yml.load(f.read())
+        hosts = yml.load(f)
     with open(groups_file, "r") as f:
-        groups = yml.load(f.read())
+        groups = yml.load(f)
     return hosts, groups
 
 
@@ -45,5 +46,5 @@ class Test(object):
 
     def test_parse_error(self):
         base_path = os.path.join(BASE_PATH, "parse_error")
-        with pytest.raises(ruamel.yaml.scanner.ScannerError):
+        with pytest.raises(ScannerError):
             ansible.parse(hostsfile=os.path.join(base_path, "source", "hosts"))


### PR DESCRIPTION
`ruamel.yaml.safe_load` is being deprecated: https://yaml.readthedocs.io/en/latest/api.html
Replaced it with `ruamel.yaml.YAML()`.
It accepts the stream directly (no need to read it first).
Arguments like `default_flow_style` are set on the `YAML` object as attribute.
Also, different parameters like `typ="safe"`, `pure=True` are quite confusing and were clarified in this SO answer: https://stackoverflow.com/questions/51316491/ruamel-yaml-clarification-on-typ-and-pure-true