### PR TITLE
Add initial expansion of DSL acronym.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Nornir
 =======
-Nornir is a pure Python automation framework intented to be used directly from Python. While most automation frameworks use their own DSL which you use to describe what you want to have done, Nornir lets you control everything from Python.
+Nornir is a pure Python automation framework intented to be used directly from Python. While most automation frameworks use their own Domain Specific Language (DSL) which you use to describe what you want to have done, Nornir lets you control everything from Python.
 
 One of the benefits we want to highlight with this approach is the ease of troubleshooting, if something goes wrong you can just use your existing debug tools directly from Python (just add a line of `import pdb` & `pdb.set_trace()` and you're good to go). Doing the same using a DSL can be quite time consuming.
 


### PR DESCRIPTION
DSL was a new acronym, at least for this usage, to me so I figured I'd add the initial expansion to the README just in case others out there don't know this usage.