### PR TITLE
Allow setting of attribute for nornir_ attributes

### DIFF
--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -199,20 +199,40 @@ class Host(object):
         """String used to connect to the device. Either ``nornir_host`` or ``self.name``"""
         return self.get("nornir_host", self.name)
 
+    @host.setter
+    def host(self, value):
+        """Allow host to be assigned as an attribute."""
+        self.data['nornir_host'] = value
+
     @property
     def username(self):
         """Either ``nornir_username`` or user running the script."""
         return self.get("nornir_username", getpass.getuser())
+
+    @username.setter
+    def username(self, value):
+        """Allow username to be assigned as an attribute."""
+        self.data['nornir_username'] = value
 
     @property
     def password(self):
         """Either ``nornir_password`` or empty string."""
         return self.get("nornir_password", "")
 
+    @password.setter
+    def password(self, value):
+        """Allow password to be assigned as an attribute."""
+        self.data['nornir_password'] = value
+
     @property
     def ssh_port(self):
         """Either ``nornir_ssh_port`` or ``None``."""
         return self.get("nornir_ssh_port")
+
+    @ssh_port.setter
+    def ssh_port(self, value):
+        """Allow ssh_port to be assigned as an attribute."""
+        self.data['nornir_ssh_port'] = value
 
     @property
     def network_api_port(self):
@@ -222,15 +242,30 @@ class Host(object):
         """
         return self.get("nornir_network_api_port")
 
+    @network_api_port.setter
+    def network_api_port(self, value):
+        """Allow network_api_port to be assigned as an attribute."""
+        self.data['nornir_network_api_port'] = value
+
     @property
     def os(self):
         """OS the device is running. Defaults to ``nornir_os``."""
         return self.get("nornir_os")
 
+    @os.setter
+    def os(self, value):
+        """Allow os to be assigned as an attribute."""
+        self.data['nornir_os'] = value
+
     @property
     def nos(self):
         """Network OS the device is running. Defaults to ``nornir_nos``."""
         return self.get("nornir_nos")
+
+    @nos.setter
+    def nos(self, value):
+        """Allow nos to be assigned as an attribute."""
+        self.data['nornir_nos'] = value
 
     def get_connection(self, connection: str) -> ConnectionPlugin:
         """

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -137,17 +137,16 @@ class Host(object):
             if g is group or g.has_parent_group(group):
                 return True
 
-    def __getattr__(self, name):
-        if name in ['host', 'username', 'password', 'ssh_port',
-                     'network_api_port', 'os', 'nos']:
-             nornir_name = f"nornir_{name}"
-             return self.data[nornir_name]
-        else:
-             return super().__getattr__(name)
-
     def __setattr__(self, name, value):
-        if name in ['host', 'username', 'password', 'ssh_port',
-                    'network_api_port', 'os', 'nos']:
+        if name in [
+            "host",
+            "username",
+            "password",
+            "ssh_port",
+            "network_api_port",
+            "os",
+            "nos",
+        ]:
             nornir_name = f"nornir_{name}"
             self.data[nornir_name] = value
         else:

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -137,6 +137,22 @@ class Host(object):
             if g is group or g.has_parent_group(group):
                 return True
 
+    def __getattr__(self, name):
+        if name in ['host', 'username', 'password', 'ssh_port',
+                     'network_api_port', 'os', 'nos']:
+             nornir_name = f"nornir_{name}"
+             return self.data[nornir_name]
+        else:
+             return super().__getattr__(name)
+
+    def __setattr__(self, name, value):
+        if name in ['host', 'username', 'password', 'ssh_port',
+                    'network_api_port', 'os', 'nos']:
+            nornir_name = f"nornir_{name}"
+            self.data[nornir_name] = value
+        else:
+            super().__setattr__(name, value)
+
     def __getitem__(self, item):
         try:
             return self.data[item]
@@ -199,40 +215,20 @@ class Host(object):
         """String used to connect to the device. Either ``nornir_host`` or ``self.name``"""
         return self.get("nornir_host", self.name)
 
-    @host.setter
-    def host(self, value):
-        """Allow host to be assigned as an attribute."""
-        self.data['nornir_host'] = value
-
     @property
     def username(self):
         """Either ``nornir_username`` or user running the script."""
         return self.get("nornir_username", getpass.getuser())
-
-    @username.setter
-    def username(self, value):
-        """Allow username to be assigned as an attribute."""
-        self.data['nornir_username'] = value
 
     @property
     def password(self):
         """Either ``nornir_password`` or empty string."""
         return self.get("nornir_password", "")
 
-    @password.setter
-    def password(self, value):
-        """Allow password to be assigned as an attribute."""
-        self.data['nornir_password'] = value
-
     @property
     def ssh_port(self):
         """Either ``nornir_ssh_port`` or ``None``."""
         return self.get("nornir_ssh_port")
-
-    @ssh_port.setter
-    def ssh_port(self, value):
-        """Allow ssh_port to be assigned as an attribute."""
-        self.data['nornir_ssh_port'] = value
 
     @property
     def network_api_port(self):
@@ -242,30 +238,15 @@ class Host(object):
         """
         return self.get("nornir_network_api_port")
 
-    @network_api_port.setter
-    def network_api_port(self, value):
-        """Allow network_api_port to be assigned as an attribute."""
-        self.data['nornir_network_api_port'] = value
-
     @property
     def os(self):
         """OS the device is running. Defaults to ``nornir_os``."""
         return self.get("nornir_os")
 
-    @os.setter
-    def os(self, value):
-        """Allow os to be assigned as an attribute."""
-        self.data['nornir_os'] = value
-
     @property
     def nos(self):
         """Network OS the device is running. Defaults to ``nornir_nos``."""
         return self.get("nornir_nos")
-
-    @nos.setter
-    def nos(self, value):
-        """Allow nos to be assigned as an attribute."""
-        self.data['nornir_nos'] = value
 
     def get_connection(self, connection: str) -> ConnectionPlugin:
         """

--- a/nornir/plugins/connections/napalm.py
+++ b/nornir/plugins/connections/napalm.py
@@ -37,9 +37,10 @@ class Napalm(ConnectionPlugin):
             "hostname": hostname,
             "username": username,
             "password": password,
-            "timeout": connection_options.get("timeout"),
             "optional_args": connection_options or {},
         }
+        if connection_options.get("timeout"):
+            parameters["timeout"] = connection_options["timeout"]
 
         network_driver = get_network_driver(nos)
         connection = network_driver(**parameters)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fs:
 __author__ = "dbarrosop@dravetech.com"
 __license__ = "Apache License, version 2"
 
-__version__ = "1.1.0"
+__version__ = "2.0.0"
 
 setup(
     name="nornir",


### PR DESCRIPTION
Do Not Merge:

Allow the nornir_ attributes that are using @property to have a setter.

This would allow you to do:

```
nornir_host.username = 'whatever'
nornir_host.password = getpass()
```

Could also implement using the @property .setter format if that is preferred.

If this looks reasonable, I will update and add unit tests (add cleanup changes unrelated to `__setattr__`).

