### PR TITLE
Patch connection close

### DIFF
--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -350,7 +350,9 @@ class Host(object):
         self.connections.pop(connection).close()
 
     def close_connections(self) -> None:
-        for connection in self.connections:
+        # Decouple deleting dictionary elements from iterating over dict
+        existing_conns = list(self.connections.keys())
+        for connection in existing_conns:
             self.close_connection(connection)
 
 

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -350,7 +350,7 @@ class Host(object):
         self.connections.pop(connection).close()
 
     def close_connections(self) -> None:
-        # Decouple deleting dictionary elements from iterating over dict
+        # Decouple deleting dictionary elements from iterating over connections dict
         existing_conns = list(self.connections.keys())
         for connection in existing_conns:
             self.close_connection(connection)


### PR DESCRIPTION
Calling this in some Nornir code:

```
brg.close_connections()
```

Generated a bunch of exceptions pertaining to dictionary size changing while iterating over dictionary:

```
hp_procurve: Traceback (most recent call last):
  File "/home/gituser/nornir/nornir/core/task.py", line 63, in start
    r = self.task(self, **self.params)
  File "/home/gituser/nornir/nornir/core/__init__.py", line 247, in close_connections_task
    task.host.close_connections()
  File "/home/gituser/nornir/nornir/core/inventory.py", line 353, in close_connections
    for connection in self.connections:
RuntimeError: dictionary changed size during iteration
```