### PR TITLE
Include interface name of 'nornir_host'

### DIFF
--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -45,10 +45,10 @@ class NBInventory(Inventory):
                     headers=headers,
                 )
                 i.raise_for_status()
-                i = i.json()
+                int_name = i.json()
 
                 # Strip extraneous information and add it to the dictionary
-                temp["primary_interface"] = i["results"][0]["interface"]["name"]
+                temp["primary_interface"] = int_name["results"][0]["interface"]["name"]
 
             # Add values that don't have an option for 'slug'
             temp["serial"] = d["serial"]

--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -40,10 +40,9 @@ class NBInventory(Inventory):
                 # Find interface name using additional API call
                 i = requests.get(
                     "{}/api/ipam/ip-addresses/?address={}".format(
-                        nb_url, temp["nornir_host"]
-                    ),
-                    headers=headers,
-                ).json()
+                        nb_url, temp["nornir_host"]),headers=headers)
+                i.raise_for_status()
+                i = i.json()
 
                 # Strip extraneous information and add it to the dictionary
                 temp["primary_interface"] = i["results"][0]["interface"]["name"]

--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -40,7 +40,10 @@ class NBInventory(Inventory):
                 # Find interface name using additional API call
                 i = requests.get(
                     "{}/api/ipam/ip-addresses/?address={}".format(
-                        nb_url, temp["nornir_host"]),headers=headers)
+                        nb_url, temp["nornir_host"]
+                    ),
+                    headers=headers,
+                )
                 i.raise_for_status()
                 i = i.json()
 

--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -37,6 +37,17 @@ class NBInventory(Inventory):
             if d.get("primary_ip", {}):
                 temp["nornir_host"] = d["primary_ip"]["address"].split("/")[0]
 
+                # Find interface name using additional API call
+                i = requests.get(
+                    "{}/api/ipam/ip-addresses/?address={}".format(
+                        nb_url, temp["nornir_host"]
+                    ),
+                    headers=headers,
+                ).json()
+
+                # Strip extraneous information and add it to the dictionary
+                temp["primary_interface"] = i["results"][0]["interface"]["name"]
+
             # Add values that don't have an option for 'slug'
             temp["serial"] = d["serial"]
             temp["vendor"] = d["device_type"]["manufacturer"]["name"]

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/address_1.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/address_1.json
@@ -1,0 +1,37 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "family": 4,
+      "address": "10.0.1.1/32",
+      "vrf": null,
+      "tenant": null,
+      "status": {
+        "value": 1,
+        "label": "Active"
+      },
+      "role": null,
+      "interface": {
+        "id": 1,
+        "url": "http://netbox.local:8080/api/dcim/interfaces/1/",
+        "device": {
+          "id": 1,
+          "url": "http://netbox.local:8080/api/dcim/devices/1/",
+          "name": "1-Core",
+          "display_name": "1-Core"
+        },
+        "virtual_machine": null,
+        "name": "lo0.0"
+      },
+      "description": "",
+      "nat_inside": null,
+      "nat_outside": null,
+      "custom_fields": {},
+      "created": "2018-07-26",
+      "last_updated": "2018-07-26T06:58:35.918980Z"
+    }
+  ]
+}

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/address_2.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/address_2.json
@@ -1,0 +1,37 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 2,
+      "family": 4,
+      "address": "172.16.2.1/32",
+      "vrf": null,
+      "tenant": null,
+      "status": {
+        "value": 1,
+        "label": "Active"
+      },
+      "role": null,
+      "interface": {
+        "id": 2,
+        "url": "http://netbox.local:8080/api/dcim/interfaces/2/",
+        "device": {
+          "id": 2,
+          "url": "http://netbox.local:8080/api/dcim/devices/2/",
+          "name": "2-Distribution",
+          "display_name": "2-Distribution"
+        },
+        "virtual_machine": null,
+        "name": "lo0.0"
+      },
+      "description": "",
+      "nat_inside": null,
+      "nat_outside": null,
+      "custom_fields": {},
+      "created": "2018-07-26",
+      "last_updated": "2018-07-26T07:23:11.518980Z"
+    }
+  ]
+}

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/address_3.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/address_3.json
@@ -1,0 +1,37 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 3,
+      "family": 4,
+      "address": "192.168.3.1/32",
+      "vrf": null,
+      "tenant": null,
+      "status": {
+        "value": 1,
+        "label": "Active"
+      },
+      "role": null,
+      "interface": {
+        "id": 3,
+        "url": "http://netbox.local:8080/api/dcim/interfaces/3/",
+        "device": {
+          "id": 3,
+          "url": "http://netbox.local:8080/api/dcim/devices/3/",
+          "name": "3-Access",
+          "display_name": "3-Access"
+        },
+        "virtual_machine": null,
+        "name": "Loopback0"
+      },
+      "description": "",
+      "nat_inside": null,
+      "nat_outside": null,
+      "custom_fields": {},
+      "created": "2018-07-26",
+      "last_updated": "2018-07-26T07:59:42.981450Z"
+    }
+  ]
+}


### PR DESCRIPTION
There was some functionality that was lacking which I thought would be useful for generating configurations from `jinja` templates.

The current implementation simply added values to a `host` that were returned by `NetBox`'s API call to `/api/dcim/devices/`.  This was missing the name of the `interface` associated with `nornir_host`.

I [asked](https://github.com/digitalocean/netbox/issues/2302) the developer of `NetBox` to include but it by default.
However, it turns out doing so would be an expensive DB operation.
So I added another API call internal to this plugin.

The explanation for adding this attribute is as follows:

>Network devices using `junos` use the format `source-address X.X.X.X` in their configuration.
>However, network devices using `ios` use the format `source-interface [NAME]` instead.

This change allows you to reference `{{ primary_interface }}` within the template.