### PR TITLE
Remove old Python 2 import

### DIFF
--- a/nornir/plugins/inventory/ansible.py
+++ b/nornir/plugins/inventory/ansible.py
@@ -1,8 +1,4 @@
-try:
-    import configparser as cp
-except ImportError:
-    # https://github.com/python/mypy/issues/1153
-    import ConfigParser as cp  # type: ignore
+import configparser as cp
 import logging
 import os
 from collections import defaultdict


### PR DESCRIPTION
I noticed that there was a leftover import for Python 2, since it's no longer supported we can remove it and clean up the code a bit.