### PR TITLE
Fix napalm plugin port reference

### DIFF
--- a/nornir/plugins/connections/napalm.py
+++ b/nornir/plugins/connections/napalm.py
@@ -35,7 +35,7 @@ class Napalm(ConnectionPlugin):
         }
         parameters.update(connection_options)
 
-        if port and "port" not in connection_options:
+        if port and "port" not in connection_options["optional_args"]:
             parameters["optional_args"]["port"] = port
 
         network_driver = get_network_driver(platform)


### PR DESCRIPTION
My understanding is that given the following inventory:

hosts.yaml
```yaml
---
nxos1:
    hostname: nxos1.twb-tech.com
    groups: 
      - nxos

nxos2:
    hostname: nxos2.twb-tech.com
    groups: 
      - nxos
```

And groups.yaml:
```yaml
---
defaults: {}
  # username: admin
  # password: <password>

nxos:
  port: 443
  napalm_options:
      platform: nxos
      connection_options:
        timeout: 300
        optional_args:
          port: 8443

nxos_ssh:
  port: 443
  napalm_options:
      platform: nxos_ssh
      connection_options:
        timeout: 300
        optional_args:
          port: 22
```

That the connection_options should map directly to the arguments of the driver which for the case of napalm would have `port` embedded in the `optional_args`

Or worded differently...first-level port, should not override a port specified in connection_options["optional_args"].