### PR TITLE
Fixing issue with napalm plugin if port but no optional_args

### DIFF
--- a/nornir/plugins/connections/napalm.py
+++ b/nornir/plugins/connections/napalm.py
@@ -35,7 +35,7 @@ class Napalm(ConnectionPlugin):
         }
         parameters.update(connection_options)
 
-        if port and "port" not in connection_options["optional_args"]:
+        if port and "port" not in parameters["optional_args"]:
             parameters["optional_args"]["port"] = port
 
         network_driver = get_network_driver(platform)


### PR DESCRIPTION
connection_options["optional_args"] might not exist (if it is not defined in inventory).

Consequently, I was getting an exception when "port" was defined in inventory, but "optional_args" was not defined.

parameters["optional_args"] will always exist.