### PR TITLE
Add class methods for plugins registration in Connections class

### DIFF
--- a/nornir/core/__init__.py
+++ b/nornir/core/__init__.py
@@ -1,12 +1,12 @@
 import logging
 import logging.config
 from multiprocessing.dummy import Pool
-from typing import Type
 
 from nornir.core.configuration import Config
-from nornir.core.connections import ConnectionPlugin
 from nornir.core.task import AggregatedResult, Task
-from nornir.plugins import connections
+from nornir.plugins.connections import register_default_connection_plugins
+
+register_default_connection_plugins()
 
 
 class Data(object):
@@ -16,12 +16,10 @@ class Data(object):
 
     Attributes:
         failed_hosts (list): Hosts that have failed to run a task properly
-        available_connections (dict): Dictionary holding available connection plugins
     """
 
     def __init__(self):
         self.failed_hosts = set()
-        self.available_connections = connections.available_connections
 
     def recover_host(self, host):
         """Remove ``host`` from list of failed hosts."""
@@ -47,8 +45,6 @@ class Nornir(object):
         dry_run(``bool``): Whether if we are testing the changes or not
         config (:obj:`nornir.core.configuration.Config`): Configuration object
         config_file (``str``): Path to Yaml configuration file
-        available_connections (``dict``): dict of connection types that will be made available.
-            Defaults to :obj:`nornir.plugins.tasks.connections.available_connections`
 
     Attributes:
         inventory (:obj:`nornir.core.inventory.Inventory`): Inventory to work with
@@ -58,14 +54,7 @@ class Nornir(object):
     """
 
     def __init__(
-        self,
-        inventory,
-        dry_run,
-        config=None,
-        config_file=None,
-        available_connections=None,
-        logger=None,
-        data=None,
+        self, inventory, dry_run, config=None, config_file=None, logger=None, data=None
     ):
         self.logger = logger or logging.getLogger("nornir")
 
@@ -80,9 +69,6 @@ class Nornir(object):
             self.config = config or Config()
 
         self.configure_logging()
-
-        if available_connections is not None:
-            self.data.available_connections = available_connections
 
     def __enter__(self):
         return self
@@ -237,10 +223,6 @@ class Nornir(object):
     def to_dict(self):
         """ Return a dictionary representing the object. """
         return {"data": self.data.to_dict(), "inventory": self.inventory.to_dict()}
-
-    def get_connection_type(self, connection: str) -> Type[ConnectionPlugin]:
-        """Returns the class for the given connection type."""
-        return self.data.available_connections[connection]
 
     def close_connections(self, on_good=True, on_failed=False):
         def close_connections_task(task):

--- a/nornir/core/connections.py
+++ b/nornir/core/connections.py
@@ -60,26 +60,26 @@ class Connections(Dict[str, ConnectionPlugin]):
     available: Dict[str, Type[ConnectionPlugin]] = {}
 
     @classmethod
-    def register(
-        cls, name: str, plugin: Type[ConnectionPlugin], force: bool = False
-    ) -> None:
+    def register(cls, name: str, plugin: Type[ConnectionPlugin]) -> None:
         """Registers a connection plugin with a specified name
 
         Args:
             name: name of the connection plugin to register
             plugin: defined connection plugin class
-            force: if set to True, will register a class with the specified name
-                even if a connection plugin with the same name was already
-                registered. Default - False
 
         Raises:
-            :obj:`nornir.core.exceptions.ConnectionPluginAlreadyRegistered`
+            :obj:`nornir.core.exceptions.ConnectionPluginAlreadyRegistered` if
+                another plugin with the specified name was already registered
         """
-        if not force and name in cls.available:
+        existing_plugin = cls.available.get(name)
+        if existing_plugin is None:
+            cls.available[name] = plugin
+        elif existing_plugin != plugin:
             raise ConnectionPluginAlreadyRegistered(
-                f"Connection {name!r} was already registered"
+                f"Connection plugin {plugin.__name__} can't be registered as "
+                f"{name!r} because plugin {existing_plugin.__name__} "
+                f"was already registered under this name"
             )
-        cls.available[name] = plugin
 
     @classmethod
     def deregister(cls, name: str) -> None:

--- a/nornir/core/exceptions.py
+++ b/nornir/core/exceptions.py
@@ -14,6 +14,14 @@ class ConnectionNotOpen(ConnectionException):
     pass
 
 
+class ConnectionPluginAlreadyRegistered(ConnectionException):
+    pass
+
+
+class ConnectionPluginNotRegistered(ConnectionException):
+    pass
+
+
 class CommandError(Exception):
     """
     Raised when there is a command error.

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -329,7 +329,7 @@ class Host(object):
         if connection in self.connections:
             raise ConnectionAlreadyOpen(connection)
 
-        self.connections[connection] = self.nornir.get_connection_type(connection)()
+        self.connections[connection] = self.connections.get_plugin(connection)()
         if default_to_host_attributes:
             conn_params = self.get_connection_parameters(connection)
             self.connections[connection].open(

--- a/nornir/plugins/connections/__init__.py
+++ b/nornir/plugins/connections/__init__.py
@@ -5,7 +5,6 @@ from nornir.core.connections import Connections
 
 
 def register_default_connection_plugins() -> None:
-    Connections.deregister_all()
     Connections.register("napalm", Napalm)
     Connections.register("netmiko", Netmiko)
     Connections.register("paramiko", Paramiko)

--- a/nornir/plugins/connections/__init__.py
+++ b/nornir/plugins/connections/__init__.py
@@ -1,16 +1,11 @@
-from typing import Dict, TYPE_CHECKING, Type
-
-
 from .napalm import Napalm
 from .netmiko import Netmiko
 from .paramiko import Paramiko
-
-if TYPE_CHECKING:
-    from nornir.core.connections import ConnectionPlugin  # noqa
+from nornir.core.connections import Connections
 
 
-available_connections: Dict[str, Type["ConnectionPlugin"]] = {
-    "napalm": Napalm,
-    "netmiko": Netmiko,
-    "paramiko": Paramiko,
-}
+def register_default_connection_plugins() -> None:
+    Connections.deregister_all()
+    Connections.register("napalm", Napalm)
+    Connections.register("netmiko", Netmiko)
+    Connections.register("paramiko", Paramiko)

--- a/tests/core/test_connections.py
+++ b/tests/core/test_connections.py
@@ -82,6 +82,7 @@ def validate_params(task, conn, params):
 class Test(object):
     @classmethod
     def setup_class(cls):
+        Connections.deregister_all()
         Connections.register("dummy", DummyConnectionPlugin)
         Connections.register("dummy_no_overrides", DummyConnectionPlugin)
 
@@ -151,6 +152,7 @@ class TestConnectionPluginsRegistration(object):
         Connections.register("another_dummy", AnotherDummyConnectionPlugin)
 
     def teardown_method(self, method):
+        Connections.deregister_all()
         register_default_connection_plugins()
 
     def test_count(self):
@@ -160,13 +162,13 @@ class TestConnectionPluginsRegistration(object):
         Connections.register("new_dummy", DummyConnectionPlugin)
         assert "new_dummy" in Connections.available
 
-    def test_register_existing(self):
-        with pytest.raises(ConnectionPluginAlreadyRegistered):
-            Connections.register("dummy", DummyConnectionPlugin)
+    def test_register_already_registered_same(self):
+        Connections.register("dummy", DummyConnectionPlugin)
+        assert Connections.available["dummy"] == DummyConnectionPlugin
 
-    def test_register_existing_force(self):
-        Connections.register("dummy", AnotherDummyConnectionPlugin, force=True)
-        assert Connections.available["dummy"] == AnotherDummyConnectionPlugin
+    def test_register_already_registered_new(self):
+        with pytest.raises(ConnectionPluginAlreadyRegistered):
+            Connections.register("dummy", AnotherDummyConnectionPlugin)
 
     def test_deregister_existing(self):
         Connections.deregister("dummy")


### PR DESCRIPTION
This API can be used internally for built-in plugins and
externally by a developer of a custom connection plugin

Usage:
```
from nornir.core.connections import Connections, ConnectionPlugin

class MyConnectionPlugin(ConnectionPlugin):
    ...


Connections.register('my', MyConnectionPlugin)
plugin = Connections.get_plugin('my')  # used internally in open_connection
Connections.deregister('my')
```

Fixes #211 
Closes #142 