### PR TITLE
Add nxos_ssh mapping to netmiko connection

### DIFF
--- a/nornir/plugins/tasks/connections/netmiko_connection.py
+++ b/nornir/plugins/tasks/connections/netmiko_connection.py
@@ -3,6 +3,7 @@ from netmiko import ConnectHandler
 napalm_to_netmiko_map = {
     "ios": "cisco_ios",
     "nxos": "cisco_nxos",
+    "nxos_ssh": "cisco_nxos",
     "eos": "arista_eos",
     "junos": "juniper_junos",
     "iosxr": "cisco_xr",


### PR DESCRIPTION
Added "nxos_ssh": "cisco_nxos"  to napalm_to_netmiko_map in netmiko_connection.py.
As per the below open issue.
Netmiko missing device_type mapping from Napalm drivers including napalm community drivers #262