### PR TITLE
Update the netmiko map with nxos_ssh

### DIFF
--- a/nornir/plugins/connections/netmiko.py
+++ b/nornir/plugins/connections/netmiko.py
@@ -8,6 +8,7 @@ from nornir.core.connections import ConnectionPlugin
 napalm_to_netmiko_map = {
     "ios": "cisco_ios",
     "nxos": "cisco_nxos",
+    "nxos_ssh": "cisco_nxos",
     "eos": "arista_eos",
     "junos": "juniper_junos",
     "iosxr": "cisco_xr",


### PR DESCRIPTION
Added "nxos_ssh": "cisco_nxos" to napalm_to_netmiko_map in nornir/plugins/connections/netmiko.py.
As per the below open issue.
Netmiko missing device_type mapping from Napalm drivers including napalm community drivers #262