### PR TITLE
Transform function options

### DIFF
--- a/docs/howto/transforming_inventory_data.ipynb
+++ b/docs/howto/transforming_inventory_data.ipynb
@@ -256,7 +256,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more information on how inheritance works check the tutorial section [inheritance model](../tutorials/intro/inventory.rst)"
+    "For more information on how inheritance works check the tutorial section [inheritance model](../tutorials/intro/inventory.rst)\n",
+    "\n",
+    "## Passing options to the transform function\n",
+    "\n",
+    "You can also pass options to the transform function, like in this example:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nornir import InitNornir\n",
+    "\n",
+    "\n",
+    "def adapt_host_data(host, password, something_else):\n",
+    "    host.data[\"password\"] = password\n",
+    "\n",
+    "    \n",
+    "options = {\n",
+    "    \"password\": \"a_secret_password\",\n",
+    "    \"something_else\": \"unused\"\n",
+    "}\n",
+    "    \n",
+    "nr = InitNornir(\n",
+    "    inventory={\n",
+    "        \"plugin\": \"nornir.plugins.inventory.simple.SimpleInventory\",\n",
+    "        \"options\": {\n",
+    "            \"host_file\": \"transforming_inventory_data/inventory/hosts.yaml\",\n",
+    "            \"group_file\": \"transforming_inventory_data/inventory/groups.yaml\",\n",
+    "        },\n",
+    "        \"transform_function\": adapt_host_data,\n",
+    "        \"transform_function_options\": options,\n",
+    "    }\n",
+    ")\n",
+    "for name, host in nr.inventory.hosts.items():\n",
+    "    print(f\"{name}.password: {host.password}\")"
    ]
   }
  ],

--- a/nornir/core/configuration.py
+++ b/nornir/core/configuration.py
@@ -15,17 +15,19 @@ class SSHConfig(object):
 
 
 class InventoryConfig(object):
-    __slots__ = "plugin", "options", "transform_function"
+    __slots__ = "plugin", "options", "transform_function", "transform_function_options"
 
     def __init__(
         self,
         plugin: Type["Inventory"],
         options: Dict[str, Any],
         transform_function: Optional[Callable[..., Any]],
+        transform_function_options: Optional[Dict[str, Any]],
     ) -> None:
         self.plugin = plugin
         self.options = options
         self.transform_function = transform_function
+        self.transform_function_options = transform_function_options
 
 
 class LoggingConfig(object):

--- a/nornir/core/deserializer/configuration.py
+++ b/nornir/core/deserializer/configuration.py
@@ -43,6 +43,9 @@ class InventoryConfig(BaseSettings):
             "you provide will run against each host in the inventory"
         ),
     )
+    transform_function_options: Dict[str, Any] = Schema(
+        default={}, description="kwargs to pass to the transform_function"
+    )
 
     class Config:
         env_prefix = "NORNIR_INVENTORY_"
@@ -55,6 +58,7 @@ class InventoryConfig(BaseSettings):
             plugin=cast(Type[Inventory], _resolve_import_from_string(inv.plugin)),
             options=inv.options,
             transform_function=_resolve_import_from_string(inv.transform_function),
+            transform_function_options=inv.transform_function_options,
         )
 
 

--- a/nornir/core/deserializer/inventory.py
+++ b/nornir/core/deserializer/inventory.py
@@ -108,7 +108,9 @@ class Inventory(BaseModel):
     defaults: Defaults
 
     @classmethod
-    def deserialize(cls, transform_function=None, *args, **kwargs):
+    def deserialize(
+        cls, transform_function=None, transform_function_options={}, *args, **kwargs
+    ):
         deserialized = cls(*args, **kwargs)
 
         defaults_dict = deserialized.defaults.dict()
@@ -131,6 +133,7 @@ class Inventory(BaseModel):
             groups=groups,
             defaults=defaults,
             transform_function=transform_function,
+            transform_function_options=transform_function_options,
         )
 
     @classmethod

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -393,6 +393,7 @@ class Inventory(object):
         groups: Optional[Groups] = None,
         defaults: Optional[Defaults] = None,
         transform_function=None,
+        transform_function_options=None,
     ) -> None:
         self.hosts = hosts
         self.groups = groups or Groups()
@@ -405,7 +406,7 @@ class Inventory(object):
 
         if transform_function:
             for h in self.hosts.values():
-                transform_function(h)
+                transform_function(h, **transform_function_options)
 
     def filter(self, filter_obj=None, filter_func=None, *args, **kwargs):
         filter_func = filter_obj or filter_func

--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -49,6 +49,7 @@ def InitNornir(config_file="", dry_run=False, configure_logging=True, **kwargs):
 
     inv = conf.inventory.plugin.deserialize(
         transform_function=conf.inventory.transform_function,
+        transform_function_options=conf.inventory.transform_function_options,
         config=conf,
         **conf.inventory.options,
     )

--- a/tests/core/deserializer/test_configuration.py
+++ b/tests/core/deserializer/test_configuration.py
@@ -28,6 +28,7 @@ class Test(object):
                 "plugin": "nornir.plugins.inventory.simple.SimpleInventory",
                 "options": {},
                 "transform_function": "",
+                "transform_function_options": {},
             },
             "ssh": {"config_file": "~/.ssh/config"},
             "logging": {
@@ -53,6 +54,7 @@ class Test(object):
                 "plugin": "nornir.plugins.inventory.simple.SimpleInventory",
                 "options": {},
                 "transform_function": "",
+                "transform_function_options": {},
             },
             "ssh": {"config_file": "~/.ssh/config"},
             "logging": {
@@ -86,6 +88,7 @@ class Test(object):
         assert c.inventory.plugin == SimpleInventory
         assert c.inventory.options == {}
         assert c.inventory.transform_function is None
+        assert c.inventory.transform_function_options == {}
 
     def test_deserialize_basic(self):
         c = ConfigDeserializer.deserialize(
@@ -112,6 +115,7 @@ class Test(object):
         assert c.inventory.plugin == AnsibleInventory
         assert c.inventory.options == {}
         assert c.inventory.transform_function is None
+        assert c.inventory.transform_function_options == {}
 
     def test_jinja_filters(self):
         c = ConfigDeserializer.deserialize(

--- a/tests/core/test_InitNornir.py
+++ b/tests/core/test_InitNornir.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 
 from nornir import InitNornir
@@ -10,6 +11,10 @@ dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitN
 
 def transform_func(host):
     host["processed_by_transform_function"] = True
+
+
+def transform_func_with_options(host, a):
+    host["a"] = a
 
 
 class StringInventory(Inventory):
@@ -104,3 +109,35 @@ class Test(object):
         )
         for host in nr.inventory.hosts.values():
             assert host["processed_by_transform_function"]
+
+    def test_InitNornir_different_transform_function_by_string_with_options(self):
+        nr = InitNornir(
+            config_file=os.path.join(dir_path, "a_config.yaml"),
+            inventory={
+                "plugin": "nornir.plugins.inventory.simple.SimpleInventory",
+                "transform_function": "tests.core.test_InitNornir.transform_func_with_options",
+                "transform_function_options": {"a": 1},
+                "options": {
+                    "host_file": "tests/inventory_data/hosts.yaml",
+                    "group_file": "tests/inventory_data/groups.yaml",
+                },
+            },
+        )
+        for host in nr.inventory.hosts.values():
+            assert host["a"] == 1
+
+    def test_InitNornir_different_transform_function_by_string_with_bad_options(self):
+        with pytest.raises(TypeError):
+            nr = InitNornir(
+                config_file=os.path.join(dir_path, "a_config.yaml"),
+                inventory={
+                    "plugin": "nornir.plugins.inventory.simple.SimpleInventory",
+                    "transform_function": "tests.core.test_InitNornir.transform_func_with_options",
+                    "transform_function_options": {"a": 1, "b": 0},
+                    "options": {
+                        "host_file": "tests/inventory_data/hosts.yaml",
+                        "group_file": "tests/inventory_data/groups.yaml",
+                    },
+                },
+            )
+            assert nr


### PR DESCRIPTION
Adds support, documentation and tests for a new `transform_function_options` inventory configuration option.

Fixes #290 