### PR TITLE
Remove the external ping test

### DIFF
--- a/tests/inventory_data/external_hosts.yaml
+++ b/tests/inventory_data/external_hosts.yaml
@@ -1,6 +1,0 @@
----
-www.github.com:
-    hostname: www.github.com
-
-dummy:
-    hostname: 1.1.1.1

--- a/tests/plugins/tasks/networking/test_tcp_ping.py
+++ b/tests/plugins/tasks/networking/test_tcp_ping.py
@@ -1,7 +1,6 @@
 import os
 
 
-from nornir import InitNornir
 from nornir.plugins.tasks import networking
 
 
@@ -42,18 +41,3 @@ class Test(object):
             processed = True
             assert isinstance(result.exception, ValueError)
         assert processed
-
-    def test_tcp_ping_external_hosts(self):
-        external = InitNornir(
-            inventory={"options": {"host_file": ext_inv_file}}, dry_run=True
-        )
-        result = external.run(networking.tcp_ping, ports=[23, 443])
-
-        assert result
-        for h, r in result.items():
-            if h == "www.github.com":
-                assert r.result[23] is False
-                assert r.result[443]
-            else:
-                assert r.result[23] is False
-                assert r.result[443]

--- a/tests/plugins/tasks/networking/test_tcp_ping.py
+++ b/tests/plugins/tasks/networking/test_tcp_ping.py
@@ -1,11 +1,6 @@
-import os
 
 
 from nornir.plugins.tasks import networking
-
-
-cur_dir = os.path.dirname(os.path.realpath(__file__))
-ext_inv_file = "{}/../../../inventory_data/external_hosts.yaml".format(cur_dir)
 
 
 class Test(object):


### PR DESCRIPTION
By having a test for external connectivity which isn't stubbed,
what's actually being tested is the network environment of the development
machine, and not the nornir code. There are several examples where
this test would legitimately fail:
- Offline laptop
- Corporate environment with restrictive firewall policies.

As such, a failing test does not necessarily indicate an issue with the
code. A failed test will cause downstream tools that depend on passing
tests to fail, or leave developers wasting time looking for non-existent
faults.