### PR TITLE
Expand user path to default ssh config

### DIFF
--- a/nornir/core/deserializer/configuration.py
+++ b/nornir/core/deserializer/configuration.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+import os
 from typing import Any, Callable, Dict, List, Optional, Type, cast
 
 from nornir.core import configuration
@@ -15,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 class SSHConfig(BaseSettings):
     config_file: str = Schema(
-        default="~/.ssh/config", description="Path to ssh configuration file"
+        default=os.path.join(os.path.expanduser("~"), ".ssh", "config"),
+        description="Path to ssh configuration file",
     )
 
     class Config:

--- a/tests/core/deserializer/test_configuration.py
+++ b/tests/core/deserializer/test_configuration.py
@@ -30,7 +30,9 @@ class Test(object):
                 "transform_function": "",
                 "transform_function_options": {},
             },
-            "ssh": {"config_file": "~/.ssh/config"},
+            "ssh": {
+                "config_file": os.path.join(os.path.expanduser("~"), ".ssh", "config")
+            },
             "logging": {
                 "level": "debug",
                 "file": "nornir.log",
@@ -56,7 +58,9 @@ class Test(object):
                 "transform_function": "",
                 "transform_function_options": {},
             },
-            "ssh": {"config_file": "~/.ssh/config"},
+            "ssh": {
+                "config_file": os.path.join(os.path.expanduser("~"), ".ssh", "config")
+            },
             "logging": {
                 "level": "debug",
                 "file": "",
@@ -83,7 +87,9 @@ class Test(object):
         assert not c.logging.to_console
         assert c.logging.loggers == ["nornir"]
 
-        assert c.ssh.config_file == "~/.ssh/config"
+        assert c.ssh.config_file == os.path.join(
+            os.path.expanduser("~"), ".ssh", "config"
+        )
 
         assert c.inventory.plugin == SimpleInventory
         assert c.inventory.options == {}


### PR DESCRIPTION
After upgrading from v1.1.0 to v2.0.0 any inventory hosts that depend on a "proxycommand" in ssh config files appear to fail connecting when the ssh config file path is not explicitly set in InitNornir ssh config options. After digging into this it appears that the default `~/.ssh/config` setting is not expanded to the full path of the user home directory thus not loading altogether. Looking at how this was handled in v1.1.0 the default was set as follows:
```
    "ssh_config_file": {
        "description": "User ssh_config_file",
        "type": "str",
        "default": os.path.join(os.path.expanduser("~"), ".ssh", "config"),
        "default_doc": "~/.ssh/config",
    },
``` 

This change sets the default setting in the configuration deserializer back to how it was handled in v1.1.0 by using `os.path.expanduser`