### PR TITLE
Fix example for Nornir 2.0

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ Here is an example on how to quickly build a runbook leveraging Nornir to retrie
     from nornir.plugins.tasks.networking import napalm_get
 
     nr = InitNornir(
-        config_file="nornir.yaml", dry_run=True, num_workers=20
+        config_file="nornir.yaml", dry_run=True
     )
 
     results = nr.run(


### PR DESCRIPTION
The first example in the documentation is incorrect after 2.0 was released.

```python
from nornir import InitNornir

nr = InitNornir(
    config_file="nornir.yaml", dry_run=True, num_workers=20
)
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/Users/patrick/.virtualenvs/meetup/lib/python3.6/site-packages/nornir/init_nornir.py", line 43, in InitNornir
    conf = Config.load_from_file(config_file, **kwargs)
  File "/Users/patrick/.virtualenvs/meetup/lib/python3.6/site-packages/nornir/core/deserializer/configuration.py", line 170, in load_from_file
    return Config.deserialize(**{**config_dict, **kwargs})
  File "/Users/patrick/.virtualenvs/meetup/lib/python3.6/site-packages/nornir/core/deserializer/configuration.py", line 152, in deserialize
    **kwargs,
  File "/Users/patrick/.virtualenvs/meetup/lib/python3.6/site-packages/pydantic/env_settings.py", line 34, in __init__
    super().__init__(**values)
  File "/Users/patrick/.virtualenvs/meetup/lib/python3.6/site-packages/pydantic/main.py", line 190, in __init__
    self.__setstate__(self._process_values(data))
  File "/Users/patrick/.virtualenvs/meetup/lib/python3.6/site-packages/pydantic/main.py", line 360, in _process_values
    return validate_model(self, input_data)
  File "/Users/patrick/.virtualenvs/meetup/lib/python3.6/site-packages/pydantic/main.py", line 533, in validate_model
    raise ValidationError(errors)
pydantic.error_wrappers.ValidationError: 1 validation error
num_workers
  extra fields not permitted (type=value_error.extra)
```

The correct way would be to use:
```
nr = InitNornir(
    config_file="nornir.yaml", dry_run=True, core={"num_workers": 20}
)
```
But I think that looks a bit more complicated than it needs to be for a first example so I removed num_workers.