### PR TITLE
Fix paramiko chan.recv_exit_status() call order

### DIFF
--- a/nornir/plugins/tasks/commands/remote_command.py
+++ b/nornir/plugins/tasks/commands/remote_command.py
@@ -30,12 +30,12 @@ def remote_command(task: Task, command: str) -> Result:
 
     chan.exec_command(command)
 
-    exit_status_code = chan.recv_exit_status()
-
     with chan.makefile() as f:
         stdout = f.read().decode()
     with chan.makefile_stderr() as f:
         stderr = f.read().decode()
+
+    exit_status_code = chan.recv_exit_status()
 
     if exit_status_code:
         raise CommandError(command, exit_status_code, stdout, stderr)


### PR DESCRIPTION
`commands.remote_command` hangs when receiving a large amount of output. This appears to be an ordering problem when `chan.recv_exit_status()` is called before doing a read.

This is ultimately a paramiko problem, discussed in this issue: https://github.com/paramiko/paramiko/issues/448

And this warning in the channel code that was the result of the paramiko issue linked above indicates that `chan.recv_exit_status()` should be called after a read: https://github.com/paramiko/paramiko/blob/cf7d49d66f3b1fbc8b0853518a54050182b3b5eb/paramiko/channel.py#L387-L396

The patch in this PR resolves hanging I have experienced when dumping large routing table output from a network host running BIRD using `commands.remote_command` in nornir.

