### PR TITLE
fix issue #319 - ascii color codes appear instead of color in output

### DIFF
--- a/nornir/plugins/functions/text/__init__.py
+++ b/nornir/plugins/functions/text/__init__.py
@@ -11,7 +11,7 @@ from nornir.core.task import AggregatedResult, MultiResult, Result
 LOCK = threading.Lock()
 
 
-init(autoreset=True, convert=False, strip=False)
+init(autoreset=True, convert=True, strip=False)
 
 
 def print_title(title: str) -> None:


### PR DESCRIPTION
Per issue #319 fixing ascii color encoding for certain terminals by re-initializing colorama terminal integration at start time.