### PR TITLE
added support to initialize SimpleInventory with native objects

### DIFF
--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -2,7 +2,12 @@ import logging
 import os
 from typing import Any
 
-from nornir.core.deserializer.inventory import GroupsDict, Inventory, VarsDict
+from nornir.core.deserializer.inventory import (
+    HostsDict,
+    GroupsDict,
+    Inventory,
+    VarsDict,
+)
 
 import ruamel.yaml
 
@@ -15,28 +20,34 @@ class SimpleInventory(Inventory):
         host_file: str = "hosts.yaml",
         group_file: str = "groups.yaml",
         defaults_file: str = "defaults.yaml",
+        hosts: HostsDict = None,
+        groups: GroupsDict = None,
+        defaults: VarsDict = None,
         *args: Any,
         **kwargs: Any
     ) -> None:
-        yml = ruamel.yaml.YAML(typ="safe")
-        with open(host_file, "r") as f:
-            hosts = yml.load(f)
+        if hosts is None:
+            yml = ruamel.yaml.YAML(typ="safe")
+            with open(host_file, "r") as f:
+                hosts = yml.load(f)
 
-        groups: GroupsDict = {}
-        if group_file:
-            if os.path.exists(group_file):
-                with open(group_file, "r") as f:
-                    groups = yml.load(f) or {}
-            else:
-                logger.debug("File %r was not found", group_file)
-                groups = {}
+        if groups is None:
+            groups = {}
+            if group_file:
+                if os.path.exists(group_file):
+                    with open(group_file, "r") as f:
+                        groups = yml.load(f) or {}
+                else:
+                    logger.debug("File %r was not found", group_file)
+                    groups = {}
 
-        defaults: VarsDict = {}
-        if defaults_file:
-            if os.path.exists(defaults_file):
-                with open(defaults_file, "r") as f:
-                    defaults = yml.load(f) or {}
-            else:
-                logger.debug("File %r was not found", defaults_file)
-                defaults = {}
+        if defaults is None:
+            defaults = {}
+            if defaults_file:
+                if os.path.exists(defaults_file):
+                    with open(defaults_file, "r") as f:
+                        defaults = yml.load(f) or {}
+                else:
+                    logger.debug("File %r was not found", defaults_file)
+                    defaults = {}
         super().__init__(hosts=hosts, groups=groups, defaults=defaults, *args, **kwargs)

--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any
+from typing import Any, Optional
 
 from nornir.core.deserializer.inventory import (
     HostsDict,
@@ -20,9 +20,9 @@ class SimpleInventory(Inventory):
         host_file: str = "hosts.yaml",
         group_file: str = "groups.yaml",
         defaults_file: str = "defaults.yaml",
-        hosts: HostsDict = None,
-        groups: GroupsDict = None,
-        defaults: VarsDict = None,
+        hosts: Optional[HostsDict] = None,
+        groups: Optional[GroupsDict] = None,
+        defaults: Optional[VarsDict] = None,
         *args: Any,
         **kwargs: Any
     ) -> None:

--- a/tests/plugins/inventory/test_simple.py
+++ b/tests/plugins/inventory/test_simple.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from nornir.plugins.inventory import simple

--- a/tests/plugins/inventory/test_simple.py
+++ b/tests/plugins/inventory/test_simple.py
@@ -1,0 +1,69 @@
+import json
+import os
+
+from nornir.plugins.inventory import simple
+from nornir.core.deserializer.inventory import Inventory
+
+BASE_PATH = os.path.join(os.path.dirname(__file__), "nsot")
+
+
+class Test(object):
+    def test_inventory(self):
+        hosts = {
+            "host1": {
+                "username": "user",
+                "groups": ["group_a"],
+                "data": {"a": 1, "b": 2},
+            },
+            "host2": {"username": "user2", "data": {"a": 1, "b": 2}},
+        }
+        groups = {"group_a": {"platform": "linux"}}
+        defaults = {"data": {"a_default": "asd"}}
+        inv = simple.SimpleInventory.deserialize(
+            hosts=hosts, groups=groups, defaults=defaults
+        )
+        assert Inventory.serialize(inv).dict() == {
+            "hosts": {
+                "host1": {
+                    "hostname": None,
+                    "port": None,
+                    "username": "user",
+                    "password": None,
+                    "platform": None,
+                    "groups": ["group_a"],
+                    "data": {"a": 1, "b": 2},
+                    "connection_options": {},
+                },
+                "host2": {
+                    "hostname": None,
+                    "port": None,
+                    "username": "user2",
+                    "password": None,
+                    "platform": None,
+                    "groups": [],
+                    "data": {"a": 1, "b": 2},
+                    "connection_options": {},
+                },
+            },
+            "groups": {
+                "group_a": {
+                    "hostname": None,
+                    "port": None,
+                    "username": None,
+                    "password": None,
+                    "platform": "linux",
+                    "groups": [],
+                    "data": {},
+                    "connection_options": {},
+                }
+            },
+            "defaults": {
+                "hostname": None,
+                "port": None,
+                "username": None,
+                "password": None,
+                "platform": None,
+                "data": {"a_default": "asd"},
+                "connection_options": {},
+            },
+        }


### PR DESCRIPTION
Solves #347 

This allows you to use either native objects or yaml files to load the SimpleInventory. For instance:

```
nr = InitNornir(inventory={
    "plugin": "nornir.plugins.inventory.SimpleInventory",
    "options": {
        "host_file": "my_hosts.yaml",
        "group_file": "my_groups.yaml",
        "defaults_file": "my_defaults.yaml",
    }
})
```

or:

```
nr = InitNornir(inventory={
    "plugin": "nornir.plugins.inventory.SimpleInventory",
    "options": {
        "hosts": {
            "host1": {
                "username": "user",
                "groups": ["group_a"],
                "data": {"a": 1, "b": 2},
            },
            "host2": {"username": "user2", "data": {"a": 1, "b": 2}},
        }
        "groups": {"group_a": {"platform": "linux"}},
        "defaults": {"data": {"a_default": "asd"}},
    }
})
```

or a combination:

```
nr = InitNornir(inventory={
    "plugin": "nornir.plugins.inventory.SimpleInventory",
    "options": {
        "hosts_file": "my_hosts.yaml",
        "groups": {"group_a": {"platform": "linux"}},
        "defaults": {"data": {"a_default": "asd"}},
    }
})
```