### PR TITLE
Updating howto documentation for including 'ConnectionOptions'

### DIFF
--- a/docs/howto/transforming_inventory_data.ipynb
+++ b/docs/howto/transforming_inventory_data.ipynb
@@ -265,9 +265,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rtr00.password: None\n",
+      "rtr01.password: None\n"
+     ]
+    }
+   ],
    "source": [
     "from nornir import InitNornir\n",
     "\n",
@@ -295,6 +304,58 @@
     "for name, host in nr.inventory.hosts.items():\n",
     "    print(f\"{name}.password: {host.password}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using ConnectionOptions\n",
+    "\n",
+    "Additionally, you might come across the need to include certain `ConnectionOptions` to be able to connect to your devices.  \n",
+    "Documentation specific to `nornir` can be found [here](../plugins/connections/index.rst) and for `napalm` can be found [here](https://napalm.readthedocs.io/en/latest/support/index.html#optional-arguments).\n",
+    "\n",
+    "The following example shows how to correctly do so in the `helpers.py`:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nornir.core.inventory import ConnectionOptions\n",
+    "\n",
+    "def adapt_host_data(host):\n",
+    "    \n",
+    "    # This function receives a Host object for manipulation\n",
+    "    host.username = host[\"user\"]\n",
+    "    host.password = host[\"password\"]\n",
+    "    host.connection_options[\"napalm\"] = ConnectionOptions(\n",
+    "        extras={\n",
+    "            \"optional_args\": {\n",
+    "                \"secret\":host.password\n",
+    "            }\n",
+    "        }\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also specify it as a `default` for your entire inventory in this manner:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nornir.core.inventory import ConnectionOptions\n",
+    "\n",
+    "nr.inventory.defaults.connection_options = ConnectionOptions(extras={\"optional_args\":{\"secret\":\"my_secret\"}})"
+   ]
   }
  ],
  "metadata": {
@@ -313,7 +374,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/docs/howto/transforming_inventory_data.ipynb
+++ b/docs/howto/transforming_inventory_data.ipynb
@@ -314,12 +314,13 @@
     "Additionally, you might come across the need to include certain `ConnectionOptions` to be able to connect to your devices.  \n",
     "Documentation specific to `nornir` can be found [here](../plugins/connections/index.rst) and for `napalm` can be found [here](https://napalm.readthedocs.io/en/latest/support/index.html#optional-arguments).\n",
     "\n",
+    "\n",
     "The following example shows how to correctly do so in the `helpers.py`:\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,12 +344,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also specify it as a `default` for your entire inventory in this manner:"
+    "You can also specify them as a `default` for your entire inventory in this manner:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
As promised in Issue #364, I've updated the howto for properly handling the `ConnectionOptions` via the `transform_function` and as well as via `nr.inventory.defaults`.

If you see any glaring errors, please let me know.