### PR TITLE
Issue #346 env var expand

### DIFF
--- a/nornir/core/deserializer/configuration.py
+++ b/nornir/core/deserializer/configuration.py
@@ -165,32 +165,32 @@ class Config(BaseNornirSettings):
     ) -> configuration.Config:
         __config_settings__ = __config_settings__ or {}
 
-        expanded_config = _deep_expand(__config_settings__)
-        expanded_kwargs = _deep_expand(kwargs)
+        # expanded_config = _deep_expand(__config_settings__)
+        # expanded_kwargs = _deep_expand(kwargs)
 
         c = Config(
             core=CoreConfig(
-                __config_settings__=expanded_config.pop("core", {}),
-                **expanded_kwargs.pop("core", {}),
+                __config_settings__=__config_settings__.pop("core", {}),
+                **kwargs.pop("core", {}),
             ),
             ssh=SSHConfig(
-                __config_settings__=expanded_config.pop("ssh", {}),
-                **expanded_kwargs.pop("ssh", {}),
+                __config_settings__=__config_settings__.pop("ssh", {}),
+                **kwargs.pop("ssh", {}),
             ),
             inventory=InventoryConfig(
-                __config_settings__=expanded_config.pop("inventory", {}),
-                **expanded_kwargs.pop("inventory", {}),
+                __config_settings__=__config_settings__.pop("inventory", {}),
+                **kwargs.pop("inventory", {}),
             ),
             logging=LoggingConfig(
-                __config_settings__=expanded_config.pop("logging", {}),
-                **expanded_kwargs.pop("logging", {}),
+                __config_settings__=__config_settings__.pop("logging", {}),
+                **kwargs.pop("logging", {}),
             ),
             jinja2=Jinja2Config(
-                __config_settings__=expanded_config.pop("jinja2", {}),
-                **expanded_kwargs.pop("jinja2", {}),
+                __config_settings__=__config_settings__.pop("jinja2", {}),
+                **kwargs.pop("jinja2", {}),
             ),
-            __config_settings__=expanded_config,
-            **expanded_kwargs,
+            __config_settings__=__config_settings__,
+            **kwargs,
         )
         return configuration.Config(
             core=CoreConfig.deserialize(**c.core.dict()),
@@ -207,8 +207,10 @@ class Config(BaseNornirSettings):
         if config_file:
             yml = ruamel.yaml.YAML(typ="safe")
             with open(config_file, "r") as f:
-                config_dict = yml.load(f) or {}
-        return Config.deserialize(__config_settings__=config_dict, **kwargs)
+                config_dict = _deep_expand(yml.load(f)) or {}
+        return Config.deserialize(
+            __config_settings__=config_dict, **_deep_expand(kwargs)
+        )
 
 
 def _deep_expand(conf) -> Any:

--- a/nornir/core/deserializer/configuration.py
+++ b/nornir/core/deserializer/configuration.py
@@ -165,9 +165,6 @@ class Config(BaseNornirSettings):
     ) -> configuration.Config:
         __config_settings__ = __config_settings__ or {}
 
-        # expanded_config = _deep_expand(__config_settings__)
-        # expanded_kwargs = _deep_expand(kwargs)
-
         c = Config(
             core=CoreConfig(
                 __config_settings__=__config_settings__.pop("core", {}),

--- a/tests/core/deserializer/test_configuration/config_w_env_vars.yaml
+++ b/tests/core/deserializer/test_configuration/config_w_env_vars.yaml
@@ -1,0 +1,13 @@
+---
+core:
+    num_workers: 10
+    raise_on_error: false
+inventory:
+    plugin: nornir.plugins.inventory.ansible.AnsibleInventory
+    options:
+      host_file: $MYVAR1/hosts.yml
+      group_file: $MYVAR1/groups.yml
+user_defined:
+    misc:
+      - $MYVAR2
+      - $MYVAR3

--- a/tests/core/test_InitNornir/a_config_w_env_vars.yaml
+++ b/tests/core/test_InitNornir/a_config_w_env_vars.yaml
@@ -1,0 +1,12 @@
+---
+core:
+    num_workers: 100
+inventory:
+    plugin: nornir.plugins.inventory.simple.SimpleInventory
+    options:
+        host_file: $HOSTS
+        group_file: $GROUPS
+user_defined:
+  data:
+    - "$RANDOM_VAR"
+    - ["$GRATUITOUSLY_NESTED_VAR"]


### PR DESCRIPTION
Implementation of suggestion by @dbarrosop in issue #346. These changes add environment variable expansion to Config#load_from_file method so that environment variables can be used in configuration files or as `kwargs` to `InitNornir`.

For example a configuration file with the following format could be used:

```
# config_file.yaml
---
core:
    num_workers: 100
inventory:
    plugin: nornir.plugins.inventory.simple.SimpleInventory
    options:
        host_file: $HOSTS
        group_file: $GROUPS
```
Or `InitNornir` could be invoked with the following `kwargs`:

```
 nr = InitNornir(
    core={"num_workers": 100},
    inventory={
        "plugin": "nornir.plugins.inventory.simple.SimpleInventory",
        "options": {"host_file": "$HOSTS", "group_file": "$GROUPS"},
    },
    user_defined={"data": ["$RANDOM_VAR"]}
)
```

The PR consists of the following changes:
- _deep_expand helper function added to `nornir/core/deserializer/configuration.py`
- Slight modification to `Config#load_from_file` method in `nornir/core/deserializer/configuration.py`
- A test config file added to `tests/core/deserializer/test_configuration/`
- Two unit tests added to `tests/core/deserializer/test_configuration.py`
- A test config file added to `tests/core/test_InitNornir`
- Two unit tests added to `tests/core/test_InitNornir.py`