### PR TITLE
Get inventory dicts

### DIFF
--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -471,4 +471,4 @@ class Inventory(object):
         return self.get_inventory_dict().get("groups")
 
     def get_hosts_dict(self):
-        raise NotImplementedError
+        return self.get_inventory_dict().get("hosts")

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -461,14 +461,26 @@ class Inventory(object):
         }
         self.groups.update(group)
 
-    def get_inventory_dict(self):
+    def get_inventory_dict(self) -> Dict:
+        """
+        Return serialized dictionary of inventory
+        """
         return deserializer.inventory.Inventory.serialize(self).dict()
 
-    def get_defaults_dict(self):
+    def get_defaults_dict(self) -> Dict:
+        """
+        Returns serialized dictionary of defaults from inventory
+        """
         return self.get_inventory_dict().get("defaults")
 
-    def get_groups_dict(self):
+    def get_groups_dict(self) -> Dict:
+        """
+        Returns serialized dictionary of groups from inventory
+        """
         return self.get_inventory_dict().get("groups")
 
-    def get_hosts_dict(self):
+    def get_hosts_dict(self) -> Dict:
+        """
+        Returns serialized dictionary of hosts from inventory
+        """
         return self.get_inventory_dict().get("hosts")

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -465,8 +465,7 @@ class Inventory(object):
         return deserializer.inventory.Inventory.serialize(self).dict()
 
     def get_defaults_dict(self):
-        inv_dict = self.get_inventory_dict()
-        return inv_dict["defaults"]
+        return self.get_inventory_dict().get("defaults")
 
     def get_groups_dict(self):
         raise NotImplementedError

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -460,3 +460,15 @@ class Inventory(object):
             )
         }
         self.groups.update(group)
+
+    def get_inventory_dict(self):
+        return deserializer.inventory.Inventory.serialize(self).dict()
+
+    def get_defaults_dict(self):
+        raise NotImplementedError
+
+    def get_groups_dict(self):
+        raise NotImplementedError
+
+    def get_hosts_dict(self):
+        raise NotImplementedError

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -471,16 +471,22 @@ class Inventory(object):
         """
         Returns serialized dictionary of defaults from inventory
         """
-        return self.get_inventory_dict().get("defaults")
+        return deserializer.inventory.Defaults.serialize(self.defaults).dict()
 
     def get_groups_dict(self) -> Dict:
         """
         Returns serialized dictionary of groups from inventory
         """
-        return self.get_inventory_dict().get("groups")
+        return {
+            k: deserializer.inventory.InventoryElement.serialize(v).dict()
+            for k, v in self.groups.items()
+        }
 
     def get_hosts_dict(self) -> Dict:
         """
         Returns serialized dictionary of hosts from inventory
         """
-        return self.get_inventory_dict().get("hosts")
+        return {
+            k: deserializer.inventory.InventoryElement.serialize(v).dict()
+            for k, v in self.hosts.items()
+        }

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -468,7 +468,7 @@ class Inventory(object):
         return self.get_inventory_dict().get("defaults")
 
     def get_groups_dict(self):
-        raise NotImplementedError
+        return self.get_inventory_dict().get("groups")
 
     def get_hosts_dict(self):
         raise NotImplementedError

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -465,7 +465,8 @@ class Inventory(object):
         return deserializer.inventory.Inventory.serialize(self).dict()
 
     def get_defaults_dict(self):
-        raise NotImplementedError
+        inv_dict = self.get_inventory_dict()
+        return inv_dict["defaults"]
 
     def get_groups_dict(self):
         raise NotImplementedError

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -294,23 +294,17 @@ class Test(object):
         )
 
     def test_get_inventory_dict(self):
-        #connection_options = {"username": "test_user", "password": "test_pass"}
-        #data = {"test_var": "test_value"}
-        #defaults = inventory.Defaults(data=data, connection_options=connection_options)
-        #g1 = inventory.Group(name="g1")
-        #g2 = inventory.Group(name="g2", groups=inventory.ParentGroups(["g1"]))
-        #h1 = inventory.Host(name="h1", groups=inventory.ParentGroups(["g1", "g2"]))
-        #h2 = inventory.Host(name="h2")
-        #hosts = {"h1": h1, "h2": h2}
-        #groups = {"g1": g1, "g2": g2}
         inv = deserializer.Inventory.deserialize(**inv_dict)
-        #g3_connection_options = {"netmiko": {"extras": {"device_type": "cisco_ios"}}}
-        #inv.add_group(
-        #    name="g3", username="test_user", connection_options=g3_connection_options
-        #)
         inventory_dict = inv.get_inventory_dict()
+        def_extras = inventory_dict["defaults"]["connection_options"]["dummy"]["extras"]
+        grp_data = inventory_dict["groups"]["group_1"]["data"]
+        host_data = inventory_dict["hosts"]["dev1.group_1"]["data"]
         assert type(inventory_dict) == dict
-
+        assert inventory_dict["defaults"]["username"] == "root"
+        assert def_extras["blah"] == "from_defaults"
+        assert "my_var" and "site" in grp_data
+        assert "www_server" and "role" in host_data
+        
     def test_get_defaults_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         defaults_dict = inv.get_defaults_dict()

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -308,7 +308,7 @@ class Test(object):
     def test_get_defaults_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         defaults_dict = inv.get_defaults_dict()
-        assert type(default_dict) == dict
+        assert type(defaults_dict) == dict
 
     def test_get_groups_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -324,4 +324,9 @@ class Test(object):
     def test_get_hosts_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         hosts_dict = inv.get_hosts_dict()
+        dev1_groups = hosts_dict["dev1.group_1"]["groups"]
+        dev2_paramiko_opts = hosts_dict["dev2.group_1"]["connection_options"]["paramiko"]
         assert type(hosts_dict) == dict
+        assert "group_1" in dev1_groups
+        assert dev2_paramiko_opts["username"] == "root"
+        assert "dev3.group_2" in hosts_dict

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -318,6 +318,8 @@ class Test(object):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         groups_dict = inv.get_groups_dict()
         assert type(groups_dict) == dict
+        assert groups_dict["group_1"]["password"] == "from_group1"
+        assert groups_dict["group_2"]["data"]["site"] == "site2"
 
     def test_get_hosts_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -308,7 +308,11 @@ class Test(object):
     def test_get_defaults_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         defaults_dict = inv.get_defaults_dict()
+        con_options = defaults_dict["connection_options"]["dummy"]
         assert type(defaults_dict) == dict
+        assert defaults_dict["username"] == "root"
+        assert con_options["hostname"] == "dummy_from_defaults"
+        assert "blah" in con_options["extras"]
 
     def test_get_groups_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -304,7 +304,7 @@ class Test(object):
         assert def_extras["blah"] == "from_defaults"
         assert "my_var" and "site" in grp_data
         assert "www_server" and "role" in host_data
-        
+
     def test_get_defaults_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         defaults_dict = inv.get_defaults_dict()
@@ -325,7 +325,9 @@ class Test(object):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         hosts_dict = inv.get_hosts_dict()
         dev1_groups = hosts_dict["dev1.group_1"]["groups"]
-        dev2_paramiko_opts = hosts_dict["dev2.group_1"]["connection_options"]["paramiko"]
+        dev2_paramiko_opts = hosts_dict["dev2.group_1"]["connection_options"][
+            "paramiko"
+        ]
         assert type(hosts_dict) == dict
         assert "group_1" in dev1_groups
         assert dev2_paramiko_opts["username"] == "root"

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -292,3 +292,36 @@ class Test(object):
             inv.groups["g3"].connection_options["netmiko"].extras["device_type"]
             == "cisco_ios"
         )
+
+    def test_get_inventory_dict(self):
+        #connection_options = {"username": "test_user", "password": "test_pass"}
+        #data = {"test_var": "test_value"}
+        #defaults = inventory.Defaults(data=data, connection_options=connection_options)
+        #g1 = inventory.Group(name="g1")
+        #g2 = inventory.Group(name="g2", groups=inventory.ParentGroups(["g1"]))
+        #h1 = inventory.Host(name="h1", groups=inventory.ParentGroups(["g1", "g2"]))
+        #h2 = inventory.Host(name="h2")
+        #hosts = {"h1": h1, "h2": h2}
+        #groups = {"g1": g1, "g2": g2}
+        inv = deserializer.Inventory.deserialize(**inv_dict)
+        #g3_connection_options = {"netmiko": {"extras": {"device_type": "cisco_ios"}}}
+        #inv.add_group(
+        #    name="g3", username="test_user", connection_options=g3_connection_options
+        #)
+        inventory_dict = inv.get_inventory_dict()
+        assert type(inventory_dict) == dict
+
+    def test_get_defaults_dict(self):
+        inv = deserializer.Inventory.deserialize(**inv_dict)
+        defaults_dict = inv.get_defaults_dict()
+        assert type(default_dict) == dict
+
+    def test_get_groups_dict(self):
+        inv = deserializer.Inventory.deserialize(**inv_dict)
+        groups_dict = inv.get_groups_dict()
+        assert type(groups_dict) == dict
+
+    def test_get_hosts_dict(self):
+        inv = deserializer.Inventory.deserialize(**inv_dict)
+        hosts_dict = inv.get_hosts_dict()
+        assert type(hosts_dict) == dict


### PR DESCRIPTION
Adding functions to nornir.core.inventory.Inventory to abstract serialization of the running inventory into dictionaries. Functions for: full inventory, defaults, groups, and hosts. This makes the inventory available in an exportable format that users could then build plugins to push out into various formats.

A simple future usecase would be to leverage the dicts to export to simple inventory files.  This would allow dynamically added inventory items to be captured and placed into a more permanent inventory.