### PR TITLE
Fix add_host and add_group methods to re-initialize inventory

### DIFF
--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -428,6 +428,17 @@ class Inventory(object):
     def __len__(self):
         return self.hosts.__len__()
 
+    def _update_group_refs(self, inventory_element: InventoryElement) -> None:
+        """
+        Returns inventory_element with updated group references for the supplied
+        inventory element
+        """
+        if hasattr(inventory_element, "groups"):
+            inventory_element.groups.refs = [
+                self.groups[p] for p in inventory_element.groups
+            ]
+        return inventory_element
+
     def children_of_group(self, group: Union[str, Group]) -> Set[Host]:
         """
         Returns set of hosts that belongs to a group including those that belong
@@ -443,25 +454,21 @@ class Inventory(object):
         """
         Add a host to the inventory after initialization
         """
-        host = {
-            name: deserializer.inventory.InventoryElement.deserialize_host(
-                name=name, defaults=self.defaults, **kwargs
-            )
-        }
+        host_element = deserializer.inventory.InventoryElement.deserialize_host(
+            name=name, defaults=self.defaults, **kwargs
+        )
+        host = {name: self._update_group_refs(host_element)}
         self.hosts.update(host)
-        self.__init__(hosts=self.hosts, groups=self.groups, defaults=self.defaults)
 
     def add_group(self, name: str, **kwargs) -> None:
         """
         Add a group to the inventory after initialization
         """
-        group = {
-            name: deserializer.inventory.InventoryElement.deserialize_group(
-                name=name, defaults=self.defaults, **kwargs
-            )
-        }
+        group_element = deserializer.inventory.InventoryElement.deserialize_group(
+            name=name, defaults=self.defaults, **kwargs
+        )
+        group = {name: self._update_group_refs(group_element)}
         self.groups.update(group)
-        self.__init__(hosts=self.hosts, groups=self.groups, defaults=self.defaults)
 
     def get_inventory_dict(self) -> Dict:
         """

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -461,6 +461,7 @@ class Inventory(object):
             )
         }
         self.groups.update(group)
+        self.__init__(hosts=self.hosts, groups=self.groups, defaults=self.defaults)
 
     def get_inventory_dict(self) -> Dict:
         """

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -449,6 +449,7 @@ class Inventory(object):
             )
         }
         self.hosts.update(host)
+        self.__init__(hosts=self.hosts, groups=self.groups, defaults=self.defaults)
 
     def add_group(self, name: str, **kwargs) -> None:
         """

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -255,7 +255,7 @@ class Test(object):
             connection_options=h3_connection_options,
         )
         assert "h3" in inv.hosts
-        assert "g1" in inv.hosts["h3"].groups
+        assert "g1" in [i.name for i in inv.hosts["h3"].groups.refs]
         assert "test_var" in inv.hosts["h3"].defaults.data.keys()
         assert inv.hosts["h3"].defaults.data.get("test_var") == "test_value"
         assert inv.hosts["h3"].platform == "TestPlatform"
@@ -284,6 +284,7 @@ class Test(object):
         inv.add_group(
             name="g3", username="test_user", connection_options=g3_connection_options
         )
+        assert "g1" in [i.name for i in inv.groups["g2"].groups.refs]
         assert "g3" in inv.groups
         assert (
             inv.groups["g3"].defaults.connection_options.get("username") == "test_user"

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -268,7 +268,7 @@ class Test(object):
         # Test with one good and one undefined group
         with pytest.raises(KeyError):
             inv.add_host(name="h5", groups=["g1", "not_defined"])
-        
+
     def test_add_group(self):
         connection_options = {"username": "test_user", "password": "test_pass"}
         data = {"test_var": "test_value"}
@@ -303,7 +303,7 @@ class Test(object):
         # Test with one defined and one undefined parent group
         with pytest.raises(KeyError):
             inv.add_group(name="g4", groups=["g1", "undefined"])
-        
+
     def test_get_inventory_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         inventory_dict = inv.get_inventory_dict()

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -263,6 +263,30 @@ class Test(object):
             inv.hosts["h3"].connection_options["netmiko"].extras["device_type"]
             == "cisco_ios"
         )
+        
+    def test_add_host_undefined_group(self):
+        data = {"test_var": "test_value"}
+        defaults = inventory.Defaults(data=data)
+        g1 = inventory.Group(name="g1")
+        g2 = inventory.Group(name="g2", groups=inventory.ParentGroups(["g1"]))
+        h1 = inventory.Host(name="h1", groups=inventory.ParentGroups(["g1", "g2"]))
+        h2 = inventory.Host(name="h2")
+        hosts = {"h1": h1, "h2": h2}
+        groups = {"g1": g1, "g2": g2}
+        inv = inventory.Inventory(hosts=hosts, groups=groups, defaults=defaults)
+        h3_connection_options = {"netmiko": {"extras": {"device_type": "cisco_ios"}}}
+        inv.add_host(
+            name="h3",
+            groups=["g1"],
+            platform="TestPlatform",
+            connection_options=h3_connection_options,
+        )
+        # Test with none of the groups correct
+        with pytest.raises(KeyError):
+            inv.add_host(name="h4", groups=["not_defined"])
+        # Test with one good and one undefined group
+        with pytest.raises(KeyError):
+            inv.add_host(name="h5", groups=["g1", "not_defined"])    
 
     def test_add_group(self):
         connection_options = {"username": "test_user", "password": "test_pass"}

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -263,31 +263,12 @@ class Test(object):
             inv.hosts["h3"].connection_options["netmiko"].extras["device_type"]
             == "cisco_ios"
         )
-        
-    def test_add_host_undefined_group(self):
-        data = {"test_var": "test_value"}
-        defaults = inventory.Defaults(data=data)
-        g1 = inventory.Group(name="g1")
-        g2 = inventory.Group(name="g2", groups=inventory.ParentGroups(["g1"]))
-        h1 = inventory.Host(name="h1", groups=inventory.ParentGroups(["g1", "g2"]))
-        h2 = inventory.Host(name="h2")
-        hosts = {"h1": h1, "h2": h2}
-        groups = {"g1": g1, "g2": g2}
-        inv = inventory.Inventory(hosts=hosts, groups=groups, defaults=defaults)
-        h3_connection_options = {"netmiko": {"extras": {"device_type": "cisco_ios"}}}
-        inv.add_host(
-            name="h3",
-            groups=["g1"],
-            platform="TestPlatform",
-            connection_options=h3_connection_options,
-        )
-        # Test with none of the groups correct
         with pytest.raises(KeyError):
             inv.add_host(name="h4", groups=["not_defined"])
         # Test with one good and one undefined group
         with pytest.raises(KeyError):
-            inv.add_host(name="h5", groups=["g1", "not_defined"])    
-
+            inv.add_host(name="h5", groups=["g1", "not_defined"])
+        
     def test_add_group(self):
         connection_options = {"username": "test_user", "password": "test_pass"}
         data = {"test_var": "test_value"}
@@ -316,7 +297,13 @@ class Test(object):
             inv.groups["g3"].connection_options["netmiko"].extras["device_type"]
             == "cisco_ios"
         )
-
+        # Test with one undefined parent group
+        with pytest.raises(KeyError):
+            inv.add_group(name="g4", groups=["undefined"])
+        # Test with one defined and one undefined parent group
+        with pytest.raises(KeyError):
+            inv.add_group(name="g4", groups=["g1", "undefined"])
+        
     def test_get_inventory_dict(self):
         inv = deserializer.Inventory.deserialize(**inv_dict)
         inventory_dict = inv.get_inventory_dict()


### PR DESCRIPTION
Referencing Issue #383 

Added line on `add_host` and `add_group` methods to re-initialize inventory.  Fixes the issue of being able to add undefined parent groups to hosts and groups when they are added dynamically using those methods of the `Inventory` class.