### PR TITLE
Fix markup for links to external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ External Resources
 
 Below you can find links to talks, blog posts, podcasts and other resources:
 
-* April 2019 - Packet Pushers podcast - [https://packetpushers.net/podcast/heavy-networking-445-an-introduction-to-the-nornir-automation-framework/](Heavy Networking 445: An Introduction To The Nornir Automation Framework)
-* May 2018 - Software Gone Wild podcast - [http://blog.ipspace.net/2018/05/network-automation-with-brigade-on.html](IPSpace podcast about nornir)
-* Sep 2018 - IPSpace network automation solutions - [https://my.ipspace.net/bin/list?id=NetAutSol&module=9#NORNIR](Nornir workshop) [slides](https://github.com/dravetech/nornir-workshop/blob/master/nornir-workshop.pdf)
-* May 2018 - Networklore - [https://networklore.com/introducing-brigade/](Introducing Nornir - The Python automation framework)
-* May 2018 - Cisco blogs - [https://blogs.cisco.com/developer/nornir-python-automation-framework](Exploring Nornir, the Python Automation Framework)
+* April 2019 - Packet Pushers podcast - [Heavy Networking 445: An Introduction To The Nornir Automation Framework](https://packetpushers.net/podcast/heavy-networking-445-an-introduction-to-the-nornir-automation-framework/)
+* May 2018 - Software Gone Wild podcast - [IPSpace podcast about nornir](http://blog.ipspace.net/2018/05/network-automation-with-brigade-on.html)
+* Sep 2018 - IPSpace network automation solutions - [Nornir workshop](https://my.ipspace.net/bin/list?id=NetAutSol&module=9#NORNIR) ([slides](https://github.com/dravetech/nornir-workshop/blob/master/nornir-workshop.pdf))
+* May 2018 - Networklore - [Introducing Nornir - The Python automation framework](https://networklore.com/introducing-brigade/)
+* May 2018 - Cisco blogs - [Exploring Nornir, the Python Automation Framework](https://blogs.cisco.com/developer/nornir-python-automation-framework)
 
 
 Bugs & New features
@@ -55,7 +55,7 @@ If you think you have bug or would like to request a new feature, please registe
 Contact & Support
 =================
 
-While we are happy to help, the [GitHub issues](<https://github.com/nornir-automation/nornir/issues>) are intended for bugs and discussions about new features. If are struggling to get something to work but don't believe its due to a bug in Nornir, the place to ask questions is in the #nornir channel in the [networktoCode Slack team](https://networktocode.herokuapp.com/).
+While we are happy to help, the [GitHub issues](https://github.com/nornir-automation/nornir/issues) are intended for bugs and discussions about new features. If are struggling to get something to work but don't believe its due to a bug in Nornir, the place to ask questions is in the #nornir channel in the [networktoCode Slack team](https://networktocode.herokuapp.com/).
 
 
 Contributing to Nornir


### PR DESCRIPTION
Text and links are swapped in the "external resources" section.