### PR TITLE
Add netmiko_commit task

### DIFF
--- a/nornir/plugins/tasks/networking/__init__.py
+++ b/nornir/plugins/tasks/networking/__init__.py
@@ -2,6 +2,7 @@ from .napalm_cli import napalm_cli
 from .napalm_configure import napalm_configure
 from .napalm_get import napalm_get
 from .napalm_validate import napalm_validate
+from .netmiko_commit import netmiko_commit
 from .netmiko_file_transfer import netmiko_file_transfer
 from .netmiko_send_command import netmiko_send_command
 from .netmiko_send_config import netmiko_send_config
@@ -13,6 +14,7 @@ __all__ = (
     "napalm_configure",
     "napalm_get",
     "napalm_validate",
+    "netmiko_commit",
     "netmiko_file_transfer",
     "netmiko_send_command",
     "netmiko_send_config",

--- a/nornir/plugins/tasks/networking/netmiko_commit.py
+++ b/nornir/plugins/tasks/networking/netmiko_commit.py
@@ -1,16 +1,21 @@
 from __future__ import unicode_literals
 
+from typing import Any
+
 from nornir.core.task import Result, Task
 
 
-def netmiko_commit(task: Task) -> Result:
+def netmiko_commit(task: Task, **kwargs: Any) -> Result:
     """
     Execute Netmiko commit method
+
+    Arguments:
+        kwargs: Additional arguments to pass to method.
 
     Returns:
         :obj: `nornir.core.task.Result`:
           * result (``str``): String showing the CLI output from the commit operation
     """
     conn = task.host.get_connection("netmiko", task.nornir.config)
-    result = conn.commit()
+    result = conn.commit(**kwargs)
     return Result(host=task.host, result=result, changed=True)

--- a/nornir/plugins/tasks/networking/netmiko_commit.py
+++ b/nornir/plugins/tasks/networking/netmiko_commit.py
@@ -3,9 +3,7 @@ from __future__ import unicode_literals
 from nornir.core.task import Result, Task
 
 
-def netmiko_commit(
-    task: Task
-) -> Result:
+def netmiko_commit(task: Task) -> Result:
     """
     Execute Netmiko commit method
 

--- a/nornir/plugins/tasks/networking/netmiko_commit.py
+++ b/nornir/plugins/tasks/networking/netmiko_commit.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+from nornir.core.task import Result, Task
+
+
+def netmiko_commit(
+    task: Task
+) -> Result:
+    """
+    Execute Netmiko commit method
+
+    Returns:
+        :obj: `nornir.core.task.Result`:
+          * result (``str``): String showing the CLI output from the commit operation
+    """
+    conn = task.host.get_connection("netmiko", task.nornir.config)
+    result = conn.commit()
+    return Result(host=task.host, result=result, changed=True)


### PR DESCRIPTION
Add netmiko_commit task to support ability to write to two-stage config devices via netmiko.