### PR TITLE
Gitlab plugin: Fix global dry_run check

### DIFF
--- a/nornir/plugins/tasks/version_control/gitlab.py
+++ b/nornir/plugins/tasks/version_control/gitlab.py
@@ -4,7 +4,7 @@ import threading
 from pathlib import Path
 from typing import Tuple
 
-from nornir.core.task import Result, Task
+from nornir.core.task import Optional, Result, Task
 
 import requests
 
@@ -160,7 +160,7 @@ def gitlab(
     filename: str,
     content: str = "",
     action: str = "create",
-    dry_run: bool = False,
+    dry_run: Optional[bool] = None,
     branch: str = "master",
     destination: str = "",
     ref: str = "master",
@@ -199,7 +199,7 @@ def gitlab(
             * diff (``str``): unified diff
 
     """
-    dry_run = task.is_dry_run(dry_run)
+    dry_run = dry_run if dry_run is not None else task.is_dry_run()
 
     session = requests.session()
     session.headers.update({"PRIVATE-TOKEN": token})


### PR DESCRIPTION
While I haven't tried this plugin I don't think it was working as intended. Since the dry_run was set to `False` in gitlab() function the call to `task.is_dry_run()` would always have returned `False`, or `True` if dry_run=True had been passed to gitlab(), since task.is_dry_run() was used I assume that the idea was to default to the global setting and instead allow dry_run to be overridden on this task level.