### PR TITLE
Fix netbox unnamed devices

### DIFF
--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -92,7 +92,9 @@ class NBInventory(Inventory):
                 host["platform"] = d["platform"]
 
             # Assign temporary dict to outer dict
-            hosts[d["name"]] = host
+            # Netbox allows devices to be unnamed, but the Nornir model does not allow this
+            # If a device is unnamed we will set the name to the id of the device in netbox
+            hosts[d.get("name") or d.get("id")] = host
 
         # Pass the data back to the parent class
         super().__init__(hosts=hosts, groups={}, defaults={}, **kwargs)

--- a/tests/plugins/inventory/netbox/2.3.5/expected.json
+++ b/tests/plugins/inventory/netbox/2.3.5/expected.json
@@ -51,6 +51,23 @@
 			},
 			"connection_options": {},
 			"groups": []
+		},
+		"4": {
+			"port": null,
+			"hostname": "10.0.1.4",
+			"username": null,
+			"password": null,
+			"platform": null,
+			"data": {
+				"serial": "",
+				"vendor": "Juniper",
+				"asset_tag": null,
+				"site": "sunnyvale-ca",
+				"role": "rt",
+				"model": "mx480"
+			},
+			"connection_options": {},
+			"groups": []
 		}
 	},
 	"groups": {},

--- a/tests/plugins/inventory/netbox/2.3.5/expected_transform_function.json
+++ b/tests/plugins/inventory/netbox/2.3.5/expected_transform_function.json
@@ -54,6 +54,24 @@
 			},
 			"connection_options": {},
 			"groups": []
+		},
+		"4": {
+			"port": null,
+			"hostname": "10.0.1.4",
+			"username": null,
+			"password": null,
+			"platform": null,
+			"data": {
+				"serial": "",
+				"vendor": "Juniper",
+				"asset_tag": null,
+				"site": "sunnyvale-ca",
+				"role": "rt",
+				"model": "mx480",
+			        "platform": "junos"
+			},
+			"connection_options": {},
+			"groups": []
 		}
 	},
 	"groups": {},

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/devices-2.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/devices-2.json
@@ -1,5 +1,5 @@
 {
-  "count": 1,
+  "count": 2,
   "next": null,
   "previous": "http://localhost:8080/api/dcim/devices/?limit=0&offset=1",
   "results": [
@@ -64,6 +64,68 @@
       "custom_fields": {"user_defined": 1},
       "created": "2018-07-12",
       "last_updated": "2018-07-12T11:53:54.866133Z"
+    },
+    {
+      "id": 4,
+      "name": null,
+      "display_name": "",
+      "device_type": {
+        "id": 11,
+        "url": "http://localhost:8080/api/dcim/device-types/11/",
+        "manufacturer": {
+          "id": 3,
+          "url": "http://localhost:8080/api/dcim/manufacturers/3/",
+          "name": "Juniper",
+          "slug": "juniper"
+        },
+        "model": "MX480",
+        "slug": "mx480"
+      },
+      "device_role": {
+        "id": 1,
+        "url": "http://localhost:8080/api/dcim/device-roles/1/",
+        "name": "Router",
+        "slug": "rt"
+      },
+      "tenant": null,
+      "platform": null,
+      "serial": "",
+      "asset_tag": null,
+      "site": {
+        "id": 3,
+        "url": "http://localhost:8080/api/dcim/sites/3/",
+        "name": "Sunnyvale, CA",
+        "slug": "sunnyvale-ca"
+      },
+      "rack": null,
+      "position": null,
+      "face": null,
+      "parent_device": null,
+      "status": {
+        "value": 1,
+        "label": "Active"
+      },
+      "primary_ip": {
+        "id": 4,
+        "url": "http://localhost:8080/api/ipam/ip-addresses/4/",
+        "family": 4,
+        "address": "10.0.1.4/32"
+      },
+      "primary_ip4": {
+        "id": 1,
+        "url": "http://localhost:8080/api/ipam/ip-addresses/4/",
+        "family": 4,
+        "address": "10.0.1.4/32"
+      },
+      "primary_ip6": null,
+      "cluster": null,
+      "virtual_chassis": null,
+      "vc_position": null,
+      "vc_priority": null,
+      "comments": "",
+      "custom_fields": {},
+      "created": "2018-07-12",
+      "last_updated": "2018-07-12T11:53:54.742412Z"
     }
   ]
 }

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/devices.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/devices.json
@@ -1,5 +1,5 @@
 {
-  "count": 3,
+  "count": 4,
   "next": null,
   "previous": null,
   "results": [
@@ -188,6 +188,68 @@
       "custom_fields": {"user_defined": 1},
       "created": "2018-07-12",
       "last_updated": "2018-07-12T11:53:54.866133Z"
+    },
+    {
+      "id": 4,
+      "name": null,
+      "display_name": "MX480",
+      "device_type": {
+        "id": 11,
+        "url": "http://localhost:8080/api/dcim/device-types/11/",
+        "manufacturer": {
+          "id": 3,
+          "url": "http://localhost:8080/api/dcim/manufacturers/3/",
+          "name": "Juniper",
+          "slug": "juniper"
+        },
+        "model": "MX480",
+        "slug": "mx480"
+      },
+      "device_role": {
+        "id": 1,
+        "url": "http://localhost:8080/api/dcim/device-roles/1/",
+        "name": "Router",
+        "slug": "rt"
+      },
+      "tenant": null,
+      "platform": null,
+      "serial": "",
+      "asset_tag": null,
+      "site": {
+        "id": 3,
+        "url": "http://localhost:8080/api/dcim/sites/3/",
+        "name": "Sunnyvale, CA",
+        "slug": "sunnyvale-ca"
+      },
+      "rack": null,
+      "position": null,
+      "face": null,
+      "parent_device": null,
+      "status": {
+        "value": 1,
+        "label": "Active"
+      },
+      "primary_ip": {
+        "id": 4,
+        "url": "http://localhost:8080/api/ipam/ip-addresses/4/",
+        "family": 4,
+        "address": "10.0.1.4/32"
+      },
+      "primary_ip4": {
+        "id": 1,
+        "url": "http://localhost:8080/api/ipam/ip-addresses/4/",
+        "family": 4,
+        "address": "10.0.1.4/32"
+      },
+      "primary_ip6": null,
+      "cluster": null,
+      "virtual_chassis": null,
+      "vc_position": null,
+      "vc_priority": null,
+      "comments": "",
+      "custom_fields": {},
+      "created": "2018-07-12",
+      "last_updated": "2018-07-12T11:53:54.742412Z"
     }
   ]
 }


### PR DESCRIPTION
Devices in Netbox don't need to have a name defined. This is usefull
to model for example switch stacks, for which individual members don't
neceseraly need a name.
In such cases we will define the Nornir host's name to the device id
in Netbox.