### PR TITLE
Add Netbox inventory plugin to documentation

### DIFF
--- a/docs/plugins/inventory/index.rst
+++ b/docs/plugins/inventory/index.rst
@@ -9,4 +9,5 @@ Inventory
 
    simple
    ansible
+   netbox
    nsot

--- a/docs/plugins/inventory/netbox.rst
+++ b/docs/plugins/inventory/netbox.rst
@@ -1,0 +1,6 @@
+Netbox
+======
+
+.. automodule:: nornir.plugins.inventory.netbox
+   :members:
+   :undoc-members:


### PR DESCRIPTION
As reported in Slack the netbox inventory plugin was missing from the documentation.