### PR TITLE
Update confusing tutorial ordering

### DIFF
--- a/docs/tutorials/intro/index.rst
+++ b/docs/tutorials/intro/index.rst
@@ -10,8 +10,8 @@ We're glad you made it here! This is a great place to learn the basics of Nornir
    Nornir at a glance <overview>
    100% Python <python>
    Installation guide <install>
-   initializing_nornir.ipynb
    inventory.ipynb
+   initializing_nornir.ipynb
    executing_tasks.ipynb
    grouping_tasks.ipynb
    task_results.ipynb


### PR DESCRIPTION
**Change**
Move inventory section one step earlier in front of initialization section

**Reasoning**
Initializing Nornir before creating an inventory file throws a FileNotFoundError for the missing inventory/hosts.yaml file. This was unexpected as a new user moving through the documentation linearly. An easy solution is to introduce the reader to the inventory section before the initialization section. Otherwise, a note on expecting the error would suffice.