### PR TITLE
add possibility to use netbox config context fields in nornir

### DIFF
--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -15,7 +15,7 @@ class NBInventory(Inventory):
         use_slugs: bool = True,
         ssl_verify: Union[bool, str] = True,
         flatten_custom_fields: bool = True,
-        flatten_config_context_fields: bool = True,
+        flatten_config_context_fields: bool = False,
         filter_parameters: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:

--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -28,6 +28,7 @@ class NBInventory(Inventory):
             use_slugs: Whether to use slugs or not
             ssl_verify: Enable/disable certificate validation or provide path to CA bundle file
             flatten_custom_fields: Whether to assign custom fields directly to the host or not
+            flatten_config_context_fields: Wheter to assign config context fields directly to the host or not
             filter_parameters: Key-value pairs to filter down hosts
         """
         filter_parameters = filter_parameters or {}
@@ -75,6 +76,12 @@ class NBInventory(Inventory):
                     host["data"][cf] = value
             else:
                 host["data"]["custom_fields"] = d["custom_fields"]
+
+            if flatten_config_context_fields:
+                for cf, value in d["config_context"].items():
+                    host["data"][cf] = value
+            else:
+                host["data"]["config_context"] = d["config_context"]
 
             # Add values that do have an option for 'slug'
             if use_slugs:

--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -15,6 +15,7 @@ class NBInventory(Inventory):
         use_slugs: bool = True,
         ssl_verify: Union[bool, str] = True,
         flatten_custom_fields: bool = True,
+        flatten_config_context_fields: bool = True,
         filter_parameters: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
I think it is a correct solution to make it possible to use config_context fields which are defined in netbox. The netbox docu tells:

> Sometimes it is desirable to associate arbitrary data with a group of devices to aid in their configuration. For example, you might want to associate a set of syslog servers for all devices at a particular site. Context data enables the association of arbitrary data to devices and virtual machines grouped by region, site, role, platform, and/or tenant. Context data is arranged hierarchically, so that data with a higher weight can be entered to override more general lower-weight data. Multiple instances of data are automatically merged by NetBox to present a single dictionary for each object.
Devices and Virtual Machines may also have a local config context defined. This local context will always overwrite the rendered config context objects for the Device/VM. This is useful in situations were the device requires a one-off value different from the rest of the environment.

With my change the netbox plugin will map these variables directly to host["data"] (flatten_config_context_fields = True (default)) or to host["data"]["config_context"] (flatten_config_context_fields = False)