### PR TITLE
cleanup items from #459

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,6 @@ output/
 
 .DS_Store
 .vscode
+.idea
 
 pip-wheel-metadata/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH="/root/.poetry/bin:$PATH" \
 RUN apt-get update \
     && apt-get install -yq curl git pandoc \
     && curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python \
-    && poetry config settings.virtualenvs.create false
+    && poetry config virtualenvs.create false
 
 COPY pyproject.toml .
 COPY poetry.lock .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ pytest-cov = "*"
 pylama = "*"
 flake8-import-order = "*"
 requests-mock = "*"
-black = {version = "^19.3b0",allows-prereleases = true}
+black = {version = "^19.3b0",allow-prereleases = true}
 mypy = "*"
 # The following dependencies are used for docs generation when run locally or in Docker
 # (e.g. poetry install)


### PR DESCRIPTION
Replaces part of #459 

Minor fixes discussed in other PR:

- Added .idea to gitignore
- Modified Dockerfile slightly -- I'm not 100% on this, but pretty sure this was just a Poetry syntax change... modified poetry config settings.virtualenvs.create false --> poetry config virtualenvs.create false. I've not really used Poetry but all the tests and such seem to work as desired and I don't get whatever error complaining about invalid setting anymore!
- Modified pyrpoject.toml setting for Black allows-prereleases --> allow-prereleases -- this was another one that just popped up saying it was/is being deported (the "allows" bit)
