### PR TITLE
Add skip mark to netconf tests

### DIFF
--- a/tests/plugins/tasks/networking/test_netconf_capabilities.py
+++ b/tests/plugins/tasks/networking/test_netconf_capabilities.py
@@ -1,6 +1,8 @@
 from nornir.plugins.tasks import networking
+from tests import skip
 
 
+@skip
 def test_netconf_capabilities(netconf):
     result = netconf.run(networking.netconf_capabilities)
 

--- a/tests/plugins/tasks/networking/test_netconf_edit_config.py
+++ b/tests/plugins/tasks/networking/test_netconf_edit_config.py
@@ -1,4 +1,5 @@
 from nornir.plugins.tasks import networking
+from tests import skip
 
 CONFIG = """
 <nc:config
@@ -19,6 +20,7 @@ CONFIG = """
 """
 
 
+@skip
 def test_netconf_edit_config(netconf):
     result = netconf.run(networking.netconf_get_config)
 

--- a/tests/plugins/tasks/networking/test_netconf_get.py
+++ b/tests/plugins/tasks/networking/test_netconf_get.py
@@ -1,6 +1,8 @@
 from nornir.plugins.tasks import networking
+from tests import skip
 
 
+@skip
 def test_netconf_get(netconf):
     result = netconf.run(networking.netconf_get)
 
@@ -8,6 +10,7 @@ def test_netconf_get(netconf):
         assert "<turing-machine" in v.result
 
 
+@skip
 def test_netconf_get_subtree(netconf):
     result = netconf.run(
         networking.netconf_get,

--- a/tests/plugins/tasks/networking/test_netconf_get_config.py
+++ b/tests/plugins/tasks/networking/test_netconf_get_config.py
@@ -1,6 +1,8 @@
 from nornir.plugins.tasks import networking
+from tests import skip
 
 
+@skip
 def test_netconf_get_config(netconf):
     result = netconf.run(networking.netconf_get_config, source="startup")
 
@@ -8,6 +10,7 @@ def test_netconf_get_config(netconf):
         assert "<turing-machine" in v.result
 
 
+@skip
 def test_netconf_get_config_subtree(netconf):
     result = netconf.run(
         networking.netconf_get_config,


### PR DESCRIPTION
Netconf tests require docker environment up and running, so outside of that they should be marked with `@skip` marker not to fail the test suite without docker.