### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 ARG PYTHON
-FROM python:${PYTHON}-slim-stretch
+FROM python:${PYTHON}-slim-buster
 
 WORKDIR /nornir
-ENV PATH="/root/.poetry/bin:$PATH" \
+ENV PATH="/nornir/.venv/bin:/root/.poetry/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     NORNIR_TESTS=1
 
 RUN apt-get update \
     && apt-get install -yq curl git pandoc \
-    && curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python \
-    && poetry config virtualenvs.create false
+    && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python \
+    && poetry config virtualenvs.in-project true
 
 COPY pyproject.toml .
 COPY poetry.lock .


### PR DESCRIPTION
* Update poetry URL
* Use a virtual environment to install dependencies, fix #464
* Use `slim-buster` base instead of `slim-stretch`. Since Python 3.8 containers with stretch base are no longer [built](https://hub.docker.com/_/python)

More regarding #464 fix, here is the output I can see with these changes:
```
...
Step 8/11 : RUN poetry install --no-interaction
 ---> Running in 2f52e681c395
Creating virtualenv nornir in /nornir/.venv
Installing dependencies from lock file
Warning: The lock file is not up to date with the latest changes in pyproject.toml. You may be getting outdated dependencies. Run update to update them.


Package operations: 114 installs, 0 updates, 0 removals

  - Installing decorator (4.4.0)
  - Installing ipython-genutils (0.2.0)
  - Installing six (1.12.0)
  - Installing attrs (19.1.0)
  - Installing parso (0.5.1)
  - Installing ptyprocess (0.6.0)
  - Installing pycparser (2.19)
  - Installing pyrsistent (0.15.4)
  - Installing traitlets (4.3.2)
  - Installing wcwidth (0.1.7)
  - Installing asn1crypto (0.24.0)
  - Installing backcall (0.1.0)
  - Installing cffi (1.12.3)
  - Installing colorama (0.4.1)
  - Installing jedi (0.15.1)
  - Installing jsonschema (3.0.2)
  - Installing jupyter-core (4.5.0)
  - Installing markupsafe (1.1.1)
  - Installing pexpect (4.7.0)
  - Installing pickleshare (0.7.5)
  - Installing prompt-toolkit (2.0.9)
  - Installing pygments (2.4.2)
  - Installing python-dateutil (2.8.0)
  - Installing pyzmq (18.1.0)
  - Installing tornado (6.0.3)
  - Installing webencodings (0.5.1)
  - Installing bcrypt (3.1.7)
  - Installing bleach (3.1.0)
  - Installing cryptography (2.7)
  - Installing defusedxml (0.6.0)
  - Installing entrypoints (0.3)
  - Installing ipython (7.8.0)
  - Installing jinja2 (2.10.1)
  - Installing jupyter-client (5.3.3)
  - Installing mistune (0.8.4)
  - Installing more-itertools (7.2.0)
  - Installing nbformat (4.4.0)
  - Installing pandocfilters (1.4.2)
  - Installing pynacl (1.3.0)
  - Installing testpath (0.4.2)
  - Installing future (0.17.1)
  - Installing ipykernel (5.1.2)
  - Installing nbconvert (5.6.0)
  - Installing paramiko (2.6.0)
  - Installing prometheus-client (0.7.1)
  - Installing send2trash (1.5.0)
  - Installing terminado (0.8.2)
  - Installing zipp (0.6.0)
  - Installing certifi (2019.9.11)
  - Installing chardet (3.0.4)
  - Installing idna (2.8)
  - Installing importlib-metadata (0.23)
  - Installing lxml (4.4.1)
  - Installing notebook (6.0.1)
  - Installing pyparsing (2.4.2)
  - Installing pyserial (3.4)
  - Installing pytz (2019.2)
  - Installing scp (0.13.2)
  - Installing textfsm (1.1.0)
  - Installing urllib3 (1.25.5)
  - Installing alabaster (0.7.12)
  - Installing atomicwrites (1.3.0)
  - Installing babel (2.7.0)
  - Installing docutils (0.15.2)
  - Installing imagesize (1.1.0)
  - Installing ncclient (0.6.6)
  - Installing netaddr (0.7.19)
  - Installing netmiko (2.4.2)
  - Installing packaging (19.2)
  - Installing pluggy (0.13.0)
  - Installing py (1.8.0)
  - Installing pyyaml (5.1.2)
  - Installing requests (2.22.0)
  - Installing snowballstemmer (1.9.1)
  - Installing sphinxcontrib-websupport (1.1.2)
  - Installing typing (3.7.4.1)
  - Installing widgetsnbextension (3.5.1)
  - Installing appdirs (1.4.3)
  - Installing click (7.0)
  - Installing coverage (4.5.4)
  - Installing dataclasses (0.6)
  - Installing ipywidgets (7.5.1)
  - Installing junos-eznc (2.2.1)
  - Installing jupyter-console (6.0.0)
  - Installing mccabe (0.6.1)
  - Installing mypy-extensions (0.4.1)
  - Installing nxapi-plumbing (0.5.2)
  - Installing pockets (0.7.2)
  - Installing pycodestyle (2.5.0)
  - Installing pydocstyle (4.0.1)
  - Installing pyeapi (0.8.2)
  - Installing pyflakes (2.1.1)
  - Installing pyiosxr (0.53)
  - Installing pytest (5.1.2)
  - Installing qtconsole (4.5.5)
  - Installing sphinx (1.8.5)
  - Installing toml (0.10.0)
  - Installing typed-ast (1.4.0)
  - Installing typing-extensions (3.7.4)
  - Installing black (19.3b0)
  - Installing flake8-import-order (0.18.1)
  - Installing jupyter (1.0.0)
  - Installing mypy (0.740)
  - Installing napalm (2.4.0)
  - Installing nbsphinx (0.4.2)
  - Installing nbval (0.9.2)
  - Installing pydantic (1.1)
  - Installing pylama (7.7.1)
  - Installing pytest-cov (2.7.1)
  - Installing requests-mock (1.7.0)
  - Installing ruamel.yaml (0.15.100)
  - Installing sphinx-issues (1.2.0)
  - Installing sphinx-rtd-theme (0.4.3)
  - Installing sphinxcontrib-napoleon (0.7)
Removing intermediate container 2f52e681c395
 ---> 89e2394946db
Step 9/11 : COPY . .
 ---> 5a78a98debb7
Step 10/11 : RUN poetry install --no-interaction
 ---> Running in f455fc249d70
Installing dependencies from lock file
Warning: The lock file is not up to date with the latest changes in pyproject.toml. You may be getting outdated dependencies. Run update to update them.

No dependencies to install or update

  - Installing nornir (2.3.0)
```
Compare this with the output in #464 

I also checked some performance numbers (but here I was lazy and didn't do multiple tests for more accurate results):

`PYTHON=3.6 docker-compose build --no-cache nornir`
slim-stretch / old dockerfile
time: 7:07.63 

slim-stretch / new dockerfile (with venv)
time: 4:17.80

slim-buster / new dockerfile (with venv)
time: 4:35.83
