### PR TITLE
Netconf connection plugin does not respect ssh config

### DIFF
--- a/nornir/plugins/connections/netconf.py
+++ b/nornir/plugins/connections/netconf.py
@@ -110,10 +110,10 @@ class Netconf(ConnectionPlugin):
             try:
                 parameters["ssh_config"] = configuration.ssh.config_file  # type: ignore
             except AttributeError:
+                parameters["ssh_config"] = None
                 pass
 
         parameters.update(extras)
-        parameters["ssh_config"] = None
 
         connection = manager.connect_ssh(**parameters)
         self.connection = connection

--- a/tests/inventory_data/netconf_hosts.yaml
+++ b/tests/inventory_data/netconf_hosts.yaml
@@ -9,3 +9,4 @@ netconf1.no_group:
                 allow_agent: False
                 hostkey_verify: False
                 look_for_keys: False
+                ssh_config: null


### PR DESCRIPTION
### Bug Description
The netconf connection plugin has a small bug which sets the `ssh_config` parameter to `None` in all cases, regardless of setting it either as an extra or via the nornir global `ssh.config_file`. This causes a user's ssh config to go unused, and if you require things like ssh proxies to connect to network devices, makes the plugin unusable. Overwriting all `ssh_config` values doesn't seem intentional and may have been left over from previous testing when the plugin was developed.

Unfortunately, ncclient will not attempt to parse a ssh config (even in a default location) unless `ssh_config` is set to something other than `None`:

https://github.com/ncclient/ncclient/blob/60c3d36ed460b77ce9055ddc4a14deeddd2131dd/ncclient/transport/ssh.py#L226-L229

### Changes Introduced With This PR
This PR only sets `ssh_config` to `None` if it is not explicitly specified as an extra and there is no config file set in `configuration.ssh.config_file`.

Also, the `ssh_config` extra parameter in `tests/inventory_data/netconf_hosts.yaml` is now marked to `null` which translates to `None` in python-land. Not passing a `ssh_config` causes the ssh config to be set to `/root/.ssh/config` which then causes test runs to fail due to the running docker container not having a ssh config.