### PR TITLE
Capirca task plugin

### DIFF
--- a/nornir/plugins/tasks/text/__init__.py
+++ b/nornir/plugins/tasks/text/__init__.py
@@ -1,4 +1,5 @@
+from .capirca_acl import capirca_acl
 from .template_file import template_file
 from .template_string import template_string
 
-__all__ = ("template_file", "template_string")
+__all__ = ("capirca_acl", "template_file", "template_string")

--- a/nornir/plugins/tasks/text/capirca_acl.py
+++ b/nornir/plugins/tasks/text/capirca_acl.py
@@ -1,0 +1,153 @@
+from capirca.lib import arista
+from capirca.lib import aruba
+from capirca.lib import brocade
+from capirca.lib import cisco
+from capirca.lib import ciscoasa
+from capirca.lib import ciscoxr
+from capirca.lib import ipset
+from capirca.lib import iptables
+from capirca.lib import juniper
+from capirca.lib import junipersrx
+from capirca.lib import naming
+from capirca.lib import nftables
+from capirca.lib import paloaltofw
+from capirca.lib import policy
+from capirca.lib import srxlo
+
+from nornir.core.task import Result, Task
+
+from typing import Set
+
+
+class CapircaError(Exception):
+    """Base Capirca error."""
+
+    pass
+
+
+class ACLParserError(CapircaError):
+    """Raised when policy parsing fails."""
+
+    pass
+
+
+class ACLGeneratorError(CapircaError):
+    """Raised when ACL generation fails."""
+
+    pass
+
+
+class PlatformNotSupported(CapircaError):
+    """Raised when a platform has no associated ACL generator."""
+
+    pass
+
+
+class PlatformTargetNotFound(CapircaError):
+    """Raised when a platform is not configured as a target in a policy file."""
+
+    pass
+
+
+ACL_GENERATORS = {
+    "arista": arista.Arista,
+    "aruba": aruba.Aruba,
+    "brocade": brocade.Brocade,
+    "cisco": cisco.Cisco,
+    "ciscoasa": ciscoasa.CiscoASA,
+    "ciscoxr": ciscoxr.CiscoXR,
+    "ipset": ipset.Ipset,
+    "iptables": iptables.Iptables,
+    "juniper": juniper.Juniper,
+    "junipersrx": junipersrx.JuniperSRX,
+    "nftables": nftables.Nftables,
+    "paloaltofw": paloaltofw.PaloAltoFW,
+    "srxlo": srxlo.SRXlo,
+}
+
+
+def capirca_acl(
+    task: Task,
+    platform: str,
+    policy_name: str,
+    def_dir: str,
+    exp: int = 2,
+    shade_check: bool = False,
+    optimize: bool = False,
+) -> Result:
+    """
+    Renders a vendor-specific ACL from a Capirca policy file.
+
+    Arguments:
+        platform (str): platform type; valid platform types are:
+            * arista
+            * aruba
+            * brocade
+            * cisco
+            * ciscoasa
+            * ciscoxr
+            * ipset
+            * iptables
+            * juniper
+            * junipersrx
+            * nftables
+            * paloaltofw
+            * srxlo
+        policy_name (str): path to the policy file to be rendered
+        def_dir (str): path to the naming definition files
+        exp (int): generate warning when a term is set to expire within exp weeks
+        shade_check (bool): check terms are not shaded by prior policy terms
+        optimize (bool): enable ACL optimization
+
+    Returns:
+        Result object with the following attributes set:
+          * result (``str``): rendered ACL
+    """
+    definitions = naming.Naming(def_dir)
+
+    try:
+        pol = policy.ParseFile(
+            policy_name,
+            definitions,
+            optimize=optimize,
+            base_dir=".",
+            shade_check=shade_check,
+        )
+    except policy.ShadingError:
+        raise
+    except (policy.Error, naming.Error):
+        raise ACLParserError("error parsing policy")
+
+    platforms: Set[str] = set()
+    for header in pol.headers:
+        platforms.update(header.platforms)
+
+    if platform not in platforms:
+        raise PlatformTargetNotFound(
+            f"platform {platform} not listed in policy file targets"
+        )
+
+    if platform in ACL_GENERATORS:
+        gen = ACL_GENERATORS[platform]
+    else:
+        raise PlatformNotSupported(f"platform {platform} is not supported")
+
+    try:
+        acl = gen(pol, exp)
+        return Result(host=task.host, result=str(acl))
+    except (
+        arista.Error,
+        aruba.Error,
+        brocade.Error,
+        cisco.Error,
+        ciscoasa.Error,
+        ciscoxr.Error,
+        ipset.Error,
+        iptables.Error,
+        juniper.Error,
+        junipersrx.Error,
+        nftables.Error,
+        paloaltofw.Error,
+        srxlo.Error,
+    ):
+        raise ACLGeneratorError(f"unable to generate acl for {policy_name}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,15 @@
 [[package]]
+category = "dev"
+description = "Abseil Python Common Libraries, see https://github.com/abseil/abseil-py."
+name = "absl-py"
+optional = false
+python-versions = "*"
+version = "0.9.0"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 category = "main"
 description = "A configurable sidebar-enabled Sphinx theme"
 name = "alabaster"
@@ -17,7 +28,7 @@ version = "1.4.3"
 [[package]]
 category = "main"
 description = "Disable App Nap on OS X 10.9"
-marker = "sys_platform == \"darwin\" or platform_system == \"Darwin\" or python_version >= \"3.3\" and sys_platform == \"darwin\""
+marker = "python_version >= \"3.3\" and sys_platform == \"darwin\" or platform_system == \"Darwin\""
 name = "appnope"
 optional = false
 python-versions = "*"
@@ -60,6 +71,7 @@ pytz = ">=2015.7"
 [[package]]
 category = "main"
 description = "Specifications for callback functions passed in to an API"
+marker = "python_version >= \"3.3\""
 name = "backcall"
 optional = false
 python-versions = "*"
@@ -113,6 +125,21 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [[package]]
+category = "dev"
+description = "Capirca"
+name = "capirca"
+optional = false
+python-versions = "*"
+version = "1.122"
+
+[package.dependencies]
+absl-py = "*"
+ipaddress = ">=1.0.22"
+mock = "*"
+ply = "*"
+six = "*"
+
+[[package]]
 category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
@@ -126,7 +153,7 @@ description = "Foreign Function Interface for Python calling C code."
 name = "cffi"
 optional = false
 python-versions = "*"
-version = "1.13.2"
+version = "1.14.0"
 
 [package.dependencies]
 pycparser = "*"
@@ -185,7 +212,7 @@ test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "
 [[package]]
 category = "main"
 description = "A backport of the dataclasses module for Python 3.6"
-marker = "python_version == \"3.6\""
+marker = "python_version >= \"3.6\" and python_version < \"3.7\""
 name = "dataclasses"
 optional = false
 python-versions = ">=3.6, <3.7"
@@ -262,6 +289,14 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "importlib-resources"]
+
+[[package]]
+category = "dev"
+description = "IPv4/IPv6 manipulation library"
+name = "ipaddress"
+optional = false
+python-versions = "*"
+version = "1.0.23"
 
 [[package]]
 category = "main"
@@ -345,6 +380,7 @@ test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
 [[package]]
 category = "main"
 description = "An autocompletion tool for Python that can be used for text editors."
+marker = "python_version >= \"3.3\""
 name = "jedi"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -473,8 +509,8 @@ category = "main"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 name = "jupyter-core"
 optional = false
-python-versions = ">=2.7, !=3.0, !=3.1, !=3.2"
-version = "4.6.1"
+python-versions = "!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,>=2.7"
+version = "4.6.2"
 
 [package.dependencies]
 pywin32 = ">=1.0"
@@ -517,6 +553,19 @@ name = "mistune"
 optional = false
 python-versions = "*"
 version = "0.8.4"
+
+[[package]]
+category = "dev"
+description = "Rolling backport of unittest.mock for all Pythons"
+name = "mock"
+optional = false
+python-versions = ">=3.6"
+version = "4.0.1"
+
+[package.extras]
+build = ["twine", "wheel", "blurb"]
+docs = ["sphinx"]
+test = ["pytest", "pytest-cov"]
 
 [[package]]
 category = "dev"
@@ -794,7 +843,7 @@ version = "0.7.0"
 [[package]]
 category = "main"
 description = "Pexpect allows easy control of interactive console applications."
-marker = "python_version >= \"3.3\" and sys_platform != \"win32\" or sys_platform != \"win32\""
+marker = "python_version >= \"3.3\" and sys_platform != \"win32\""
 name = "pexpect"
 optional = false
 python-versions = "*"
@@ -806,6 +855,7 @@ ptyprocess = ">=0.5"
 [[package]]
 category = "main"
 description = "Tiny 'shelve'-like database with concurrency support"
+marker = "python_version >= \"3.3\""
 name = "pickleshare"
 optional = false
 python-versions = "*"
@@ -826,6 +876,14 @@ version = ">=0.12"
 
 [package.extras]
 dev = ["pre-commit", "tox"]
+
+[[package]]
+category = "dev"
+description = "Python Lex & Yacc"
+name = "ply"
+optional = false
+python-versions = "*"
+version = "3.11"
 
 [[package]]
 category = "main"
@@ -1292,11 +1350,12 @@ category = "main"
 description = "Sphinx API for Web Apps"
 name = "sphinxcontrib-websupport"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.1.2"
+python-versions = ">=3.5"
+version = "1.2.0"
 
 [package.extras]
-test = ["pytest", "mock"]
+lint = ["flake8"]
+test = ["pytest", "sqlalchemy", "whoosh", "sphinx"]
 
 [[package]]
 category = "main"
@@ -1455,7 +1514,7 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "2.1.0"
+version = "2.2.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
@@ -1465,10 +1524,13 @@ testing = ["jaraco.itertools"]
 docs = ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-napoleon", "jupyter", "nbsphinx", "pygments", "sphinx-issues"]
 
 [metadata]
-content-hash = "46c3449877cc2774a6f44a4d14895a2fe38933b23e76aefda7a7a9fcf252dd85"
+content-hash = "be4a87891c5263a29911d996df5e665c87397ceddfac5cc73d4594d4b1ce5cf0"
 python-versions = "^3.6"
 
 [metadata.files]
+absl-py = [
+    {file = "absl-py-0.9.0.tar.gz", hash = "sha256:75e737d6ce7723d9ff9b7aa1ba3233c34be62ef18d5859e706b8fdc828989830"},
+]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
@@ -1525,44 +1587,43 @@ bleach = [
     {file = "bleach-3.1.0-py2.py3-none-any.whl", hash = "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16"},
     {file = "bleach-3.1.0.tar.gz", hash = "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"},
 ]
+capirca = [
+    {file = "capirca-1.122-py3-none-any.whl", hash = "sha256:90a7400e5e71d70fa4e47af1c059adfe9d75cc07b5e0216dfda38714a8c07375"},
+    {file = "capirca-1.122.tar.gz", hash = "sha256:6bb403cf302eab7c613b41b6e49b8ed6bbc9df05dd40566fc46ab3dd652086ec"},
+]
 certifi = [
     {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
     {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
 ]
 cffi = [
-    {file = "cffi-1.13.2-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43"},
-    {file = "cffi-1.13.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396"},
-    {file = "cffi-1.13.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54"},
-    {file = "cffi-1.13.2-cp27-cp27m-win32.whl", hash = "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159"},
-    {file = "cffi-1.13.2-cp27-cp27m-win_amd64.whl", hash = "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97"},
-    {file = "cffi-1.13.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579"},
-    {file = "cffi-1.13.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc"},
-    {file = "cffi-1.13.2-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f"},
-    {file = "cffi-1.13.2-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858"},
-    {file = "cffi-1.13.2-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42"},
-    {file = "cffi-1.13.2-cp34-cp34m-win32.whl", hash = "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b"},
-    {file = "cffi-1.13.2-cp34-cp34m-win_amd64.whl", hash = "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20"},
-    {file = "cffi-1.13.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3"},
-    {file = "cffi-1.13.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25"},
-    {file = "cffi-1.13.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5"},
-    {file = "cffi-1.13.2-cp35-cp35m-win32.whl", hash = "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c"},
-    {file = "cffi-1.13.2-cp35-cp35m-win_amd64.whl", hash = "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b"},
-    {file = "cffi-1.13.2-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04"},
-    {file = "cffi-1.13.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652"},
-    {file = "cffi-1.13.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57"},
-    {file = "cffi-1.13.2-cp36-cp36m-win32.whl", hash = "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e"},
-    {file = "cffi-1.13.2-cp36-cp36m-win_amd64.whl", hash = "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"},
-    {file = "cffi-1.13.2-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410"},
-    {file = "cffi-1.13.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a"},
-    {file = "cffi-1.13.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12"},
-    {file = "cffi-1.13.2-cp37-cp37m-win32.whl", hash = "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e"},
-    {file = "cffi-1.13.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a"},
-    {file = "cffi-1.13.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d"},
-    {file = "cffi-1.13.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3"},
-    {file = "cffi-1.13.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db"},
-    {file = "cffi-1.13.2-cp38-cp38-win32.whl", hash = "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506"},
-    {file = "cffi-1.13.2-cp38-cp38-win_amd64.whl", hash = "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba"},
-    {file = "cffi-1.13.2.tar.gz", hash = "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346"},
+    {file = "cffi-1.14.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384"},
+    {file = "cffi-1.14.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30"},
+    {file = "cffi-1.14.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"},
+    {file = "cffi-1.14.0-cp27-cp27m-win32.whl", hash = "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78"},
+    {file = "cffi-1.14.0-cp27-cp27m-win_amd64.whl", hash = "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793"},
+    {file = "cffi-1.14.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e"},
+    {file = "cffi-1.14.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a"},
+    {file = "cffi-1.14.0-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff"},
+    {file = "cffi-1.14.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f"},
+    {file = "cffi-1.14.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa"},
+    {file = "cffi-1.14.0-cp35-cp35m-win32.whl", hash = "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5"},
+    {file = "cffi-1.14.0-cp35-cp35m-win_amd64.whl", hash = "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4"},
+    {file = "cffi-1.14.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d"},
+    {file = "cffi-1.14.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc"},
+    {file = "cffi-1.14.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac"},
+    {file = "cffi-1.14.0-cp36-cp36m-win32.whl", hash = "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f"},
+    {file = "cffi-1.14.0-cp36-cp36m-win_amd64.whl", hash = "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b"},
+    {file = "cffi-1.14.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3"},
+    {file = "cffi-1.14.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66"},
+    {file = "cffi-1.14.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0"},
+    {file = "cffi-1.14.0-cp37-cp37m-win32.whl", hash = "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f"},
+    {file = "cffi-1.14.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26"},
+    {file = "cffi-1.14.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd"},
+    {file = "cffi-1.14.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55"},
+    {file = "cffi-1.14.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2"},
+    {file = "cffi-1.14.0-cp38-cp38-win32.whl", hash = "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8"},
+    {file = "cffi-1.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b"},
+    {file = "cffi-1.14.0.tar.gz", hash = "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -1668,6 +1729,10 @@ importlib-metadata = [
     {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
     {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
 ]
+ipaddress = [
+    {file = "ipaddress-1.0.23-py2.py3-none-any.whl", hash = "sha256:6e0f4a39e66cb5bb9a137b00276a2eff74f93b71dcbdad6f10ff7df9d3557fcc"},
+    {file = "ipaddress-1.0.23.tar.gz", hash = "sha256:b7f8e0369580bb4a24d5ba1d7cc29660a4a6987763faf1d8a8046830e020e7e2"},
+]
 ipykernel = [
     {file = "ipykernel-5.1.4-py3-none-any.whl", hash = "sha256:ba8c9e5561f3223fb47ce06ad7925cb9444337ac367341c0c520ffb68ea6d120"},
     {file = "ipykernel-5.1.4.tar.gz", hash = "sha256:7f1f01df22f1229c8879501057877ccaf92a3b01c1d00db708aad5003e5f9238"},
@@ -1714,8 +1779,8 @@ jupyter-console = [
     {file = "jupyter_console-6.1.0.tar.gz", hash = "sha256:6f6ead433b0534909df789ea64f0a14cdf9b6b2360757756f08182be4b9e431b"},
 ]
 jupyter-core = [
-    {file = "jupyter_core-4.6.1-py2.py3-none-any.whl", hash = "sha256:464769f7387d7a62a2403d067f1ddc616655b7f77f5d810c0dd62cb54bfd0fb9"},
-    {file = "jupyter_core-4.6.1.tar.gz", hash = "sha256:a183e0ec2e8f6adddf62b0a3fc6a2237e3e0056d381e536d3e7c7ecc3067e244"},
+    {file = "jupyter_core-4.6.2-py2.py3-none-any.whl", hash = "sha256:e91785b8bd7f752711c0c20e5ec6ba0d42178d6321a61396082c55818991caee"},
+    {file = "jupyter_core-4.6.2.tar.gz", hash = "sha256:185dfe42800585ca860aa47b5fe0211ee2c33246576d2d664b0b0b8d22aacf3a"},
 ]
 lxml = [
     {file = "lxml-4.5.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0701f7965903a1c3f6f09328c1278ac0eee8f56f244e66af79cb224b7ef3801c"},
@@ -1774,6 +1839,11 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mccabe = [
@@ -1783,6 +1853,10 @@ mccabe = [
 mistune = [
     {file = "mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"},
     {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
+]
+mock = [
+    {file = "mock-4.0.1-py3-none-any.whl", hash = "sha256:5e48d216809f6f393987ed56920305d8f3c647e6ed35407c1ff2ecb88a9e1151"},
+    {file = "mock-4.0.1.tar.gz", hash = "sha256:2a572b715f09dd2f0a583d8aeb5bb67d7ed7a8fd31d193cf1227a99c16a67bc3"},
 ]
 more-itertools = [
     {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
@@ -1876,6 +1950,10 @@ pickleshare = [
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+ply = [
+    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
+    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
 ]
 pockets = [
     {file = "pockets-0.9.1-py2.py3-none-any.whl", hash = "sha256:68597934193c08a08eb2bf6a1d85593f627c22f9b065cc727a4f03f669d96d86"},
@@ -2137,8 +2215,8 @@ sphinxcontrib-napoleon = [
     {file = "sphinxcontrib_napoleon-0.7-py2.py3-none-any.whl", hash = "sha256:711e41a3974bdf110a484aec4c1a556799eb0b3f3b897521a018ad7e2db13fef"},
 ]
 sphinxcontrib-websupport = [
-    {file = "sphinxcontrib-websupport-1.1.2.tar.gz", hash = "sha256:1501befb0fdf1d1c29a800fdbf4ef5dc5369377300ddbdd16d2cd40e54c6eefc"},
-    {file = "sphinxcontrib_websupport-1.1.2-py2.py3-none-any.whl", hash = "sha256:e02f717baf02d0b6c3dd62cf81232ffca4c9d5c331e03766982e3ff9f1d2bc3f"},
+    {file = "sphinxcontrib-websupport-1.2.0.tar.gz", hash = "sha256:bad3fbd312bc36a31841e06e7617471587ef642bdacdbdddaa8cc30cf251b5ea"},
+    {file = "sphinxcontrib_websupport-1.2.0-py2.py3-none-any.whl", hash = "sha256:50fb98fcb8ff2a8869af2afa6b8ee51b3baeb0b17dacd72505105bf15d506ead"},
 ]
 terminado = [
     {file = "terminado-0.8.3-py2.py3-none-any.whl", hash = "sha256:a43dcb3e353bc680dd0783b1d9c3fc28d529f190bc54ba9a229f72fe6e7a54d7"},
@@ -2221,6 +2299,6 @@ yamlordereddictloader = [
     {file = "yamlordereddictloader-0.4.0.tar.gz", hash = "sha256:7f30f0b99ea3f877f7cb340c570921fa9d639b7f69cba18be051e27f8de2080e"},
 ]
 zipp = [
-    {file = "zipp-2.1.0-py3-none-any.whl", hash = "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28"},
-    {file = "zipp-2.1.0.tar.gz", hash = "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"},
+    {file = "zipp-2.2.0-py36-none-any.whl", hash = "sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"},
+    {file = "zipp-2.2.0.tar.gz", hash = "sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ jupyter = "^1"
 nbsphinx = "^0.5"
 pygments = "^2"
 sphinx-issues = "^1.2"
+capirca = "^1.122"
 
 [tool.poetry.extras]
 # The following section is required to install docs dependencies

--- a/tests/inventory_data/hosts.yaml
+++ b/tests/inventory_data/hosts.yaml
@@ -73,6 +73,11 @@ dev3.group_2:
     data:
         www_server: apache
         role: www
+        capirca:
+            platform: arista
+            expiration: 2
+            shade_check: true
+            optimize: true
     groups:
         - group_2
     connection_options:
@@ -92,6 +97,11 @@ dev4.group_2:
     data:
         my_var: comes_from_dev4.group_2
         role: db
+        capirca:
+            platform: juniper
+            expiration: 2
+            shade_check: true
+            optimize: true
     groups:
         - group_2
         - parent_group

--- a/tests/plugins/tasks/text/test_capirca_acl.py
+++ b/tests/plugins/tasks/text/test_capirca_acl.py
@@ -1,0 +1,143 @@
+import os
+
+from nornir.plugins.tasks import text
+
+
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+INPUT_POLICY = f"{BASE_DIR}/test_data/nornir.pol"
+DEFINITIONS_DIR = f"{BASE_DIR}/test_data/def"
+
+
+ARISTA_ACL = """! $Id:$
+! $Date:$
+! $Revision:$
+no ip access-list LOOPBACK
+ip access-list LOOPBACK
+ remark $Id:$
+ remark Sample multitarget loopback filter
+
+
+ remark accept-icmp
+ permit icmp any any
+
+
+ remark accept-traceroute
+ remark Allow inbound traceroute from any source.
+ remark Owner: jeff
+ permit udp any any range 33434 33534
+
+
+ remark accept-ospf
+ remark Allow outbound OSPF traffic from other RFC1918 routers.
+ permit ospf 10.0.0.0/8 any
+ permit ospf 172.16.0.0/12 any
+ permit ospf 192.168.0.0/16 any
+
+
+ remark discard-default
+ deny ip any any
+
+exit
+"""
+
+JUNIPER_ACL = """firewall {
+    family inet {
+        replace:
+        /*
+        ** $Id:$
+        ** $Date:$
+        ** $Revision:$
+        **
+        ** Sample multitarget loopback filter
+        */
+        filter LOOPBACK {
+            interface-specific;
+            term accept-icmp {
+                from {
+                    protocol icmp;
+                }
+                then {
+                    count icmp-loopback;
+                    policer rate-limit-icmp;
+                    accept;
+                }
+            }
+            /*
+            ** Allow inbound traceroute from any source.
+            ** Owner: jeff
+            */
+            term accept-traceroute {
+                from {
+                    protocol udp;
+                    destination-port 33434-33534;
+                }
+                then {
+                    count inbound-traceroute;
+                    policer rate-limit-to-router;
+                    accept;
+                }
+            }
+            /*
+            ** Allow outbound OSPF traffic from other RFC1918 routers.
+            */
+            term accept-ospf {
+                from {
+                    source-address {
+                        /* non-public */
+                        10.0.0.0/8;
+                        /* non-public */
+                        172.16.0.0/12;
+                        /* non-public */
+                        192.168.0.0/16;
+                    }
+                    protocol ospf;
+                }
+                then {
+                    count ospf;
+                    accept;
+                }
+            }
+            term discard-default {
+                then {
+                    count discard-default;
+                    discard;
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def gen_acl(task):
+    return task.run(
+        task=text.capirca_acl,
+        platform=task.host["capirca"]["platform"],
+        policy_name=INPUT_POLICY,
+        def_dir=DEFINITIONS_DIR,
+        exp=task.host["capirca"]["expiration"],
+        shade_check=task.host["capirca"]["shade_check"],
+        optimize=task.host["capirca"]["optimize"],
+    )
+
+
+class Test:
+    def test_gen_acl(self, nornir):
+        hosts = nornir.filter(site="site2")
+        result = hosts.run(task=gen_acl)
+        got = result["dev3.group_2"][0].result[0].result
+        assert got == ARISTA_ACL
+        got = result["dev4.group_2"][0].result[0].result
+        assert got == JUNIPER_ACL
+
+    def test_platform_not_supported(self, nornir):
+        hosts = nornir.filter(name="dev3.group_2")
+        hosts.inventory.hosts["dev3.group_2"].data["capirca"]["platform"] = "crisco"
+        result = hosts.run(task=gen_acl)
+        assert result["dev3.group_2"][0].failed
+
+    def test_platform_target_not_found(self, nornir):
+        hosts = nornir.filter(name="dev3.group_2")
+        hosts.inventory.hosts["dev3.group_2"].data["capirca"]["platform"] = "cisco"
+        result = hosts.run(task=gen_acl)
+        assert result["dev3.group_2"][0].failed

--- a/tests/plugins/tasks/text/test_data/def/NETWORK.net
+++ b/tests/plugins/tasks/text/test_data/def/NETWORK.net
@@ -1,0 +1,90 @@
+#
+# Sample naming defintions for network objects
+#
+RFC1918 = 10.0.0.0/8      # non-public
+          172.16.0.0/12   # non-public
+          192.168.0.0/16  # non-public
+
+INTERNAL = RFC1918
+
+LOOPBACK = 127.0.0.0/8  # loopback
+           ::1/128       # ipv6 loopback
+
+RFC_3330 = 169.254.0.0/16  # special use IPv4 addresses - netdeploy
+
+RFC_6598 = 100.64.0.0/10   # Shared Address Space
+
+LINKLOCAL = FE80::/10  # IPv6 link-local
+
+SITELOCAL = FEC0::/10    # Ipv6 Site-local
+
+MULTICAST = 224.0.0.0/4  # IP multicast
+            FF00::/8     # IPv6 multicast
+
+CLASS-E   = 240.0.0.0/4
+
+RESERVED = 0.0.0.0/8           # reserved
+           RFC1918
+           LOOPBACK
+           RFC_3330
+           RFC_6598
+           MULTICAST
+           CLASS-E
+           0000::/8            # reserved by IETF
+           0100::/8            # reserved by IETF
+           0200::/7            # reserved by IETF
+           0400::/6            # reserved by IETF
+           0800::/5            # reserved by IETF
+           1000::/4            # reserved by IETF
+           4000::/3            # reserved by IETF
+           6000::/3            # reserved by IETF
+           8000::/3            # reserved by IETF
+           A000::/3            # reserved by IETF
+           C000::/3            # reserved by IETF
+           E000::/4            # reserved by IETF
+           F000::/5            # reserved by IETF
+           F800::/6            # reserved by IETF
+           FC00::/7            # unique local unicast
+           FE00::/9            # reserved by IETF
+           LINKLOCAL           # link local unicast
+           SITELOCAL           # IPv6 site-local
+
+ANY = 0.0.0.0/0
+
+# http://www.team-cymru.org/Services/Bogons/bogon-bn-agg.txt
+# 22-Apr-2011
+BOGON = 0.0.0.0/8
+        192.0.0.0/24
+        192.0.2.0/24
+        198.18.0.0/15
+        198.51.100.0/24
+        203.0.113.0/24
+        MULTICAST
+        CLASS-E
+        3FFE::/16      # 6bone
+        5F00::/8       # 6bone
+        2001:DB8::/32  # IPv6 documentation prefix
+
+GOOGLE_PUBLIC_DNS_ANYCAST = 8.8.4.4/32               # IPv4 Anycast
+                            8.8.8.8/32               # IPv4 Anycast
+                            2001:4860:4860::8844/128 # IPv6 Anycast
+                            2001:4860:4860::8888/128 # IPv6 Anycast
+GOOGLE_DNS = GOOGLE_PUBLIC_DNS_ANYCAST
+
+
+# The following are sample entires intended for us in the included
+# sample policy file.  These should be removed.
+
+WEB_SERVERS = 200.1.1.1/32  # Example web server 1
+              200.1.1.2/32  # Example web server 2
+
+MAIL_SERVERS = 200.1.1.4/32 # Example mail server 1
+               200.1.1.5/32 # Example mail server 2
+
+PUBLIC_NAT = 200.1.1.3/32   # Example company NAT address
+
+NTP_SERVERS = 10.0.0.1/32   # Example NTP server
+              10.0.0.2/32   # Example NTP server
+
+TACACS_SERVERS = 10.1.0.1/32  # Example tacacs server
+                 10.1.0.2/32  # Example tacacs server

--- a/tests/plugins/tasks/text/test_data/def/SERVICES.svc
+++ b/tests/plugins/tasks/text/test_data/def/SERVICES.svc
@@ -1,0 +1,63 @@
+#
+# Sample naming service definitions
+#
+WHOIS = 43/udp
+SSH = 22/tcp
+TELNET = 23/tcp
+SMTP = 25/tcp
+MAIL_SERVICES = SMTP
+                ESMTP
+                SMTP_SSL
+                POP_SSL
+TIME = 37/tcp 37/udp
+TACACS = 49/tcp
+DNS = 53/tcp 53/udp
+BOOTPS = 67/udp   # BOOTP server
+BOOTPC = 68/udp   # BOOTP client
+DHCP = BOOTPS
+       BOOTPC
+TFTP = 69/tcp 69/udp
+HTTP = 80/tcp
+WEB_SERVICES = HTTP HTTPS
+POP3 = 110/tcp
+RPC = 111/udp
+IDENT = 113/tcp 113/udp
+NNTP = 119/tcp
+NTP = 123/tcp 123/udp
+MS_RPC_EPMAP = 135/udp 135/tcp
+MS_137 = 137/udp
+MS_138 = 138/udp
+MS_139 = 139/tcp
+IMAP = 143/tcp
+SNMP = 161/udp
+SNMP_TRAP = 162/udp
+BGP = 179/tcp
+IMAP3 = 220/tcp
+LDAP = 389/tcp
+LDAP_SERVICE = LDAP
+               LDAPS
+HTTPS = 443/tcp
+MS_445 = 445/tcp
+SMTP_SSL = 465/tcp
+IKE = 500/udp
+SYSLOG = 514/udp
+RTSP = 554/tcp
+ESMTP = 587/tcp
+LDAPS = 636/tcp
+IMAPS = 993/tcp
+POP_SSL = 995/tcp
+HIGH_PORTS = 1024-65535/tcp 1024-65535/udp
+MSSQL = 1433/tcp
+MSSQL_MONITOR = 1434/tcp
+RADIUS = 1812/tcp 1812/udp
+HSRP = 1985/udp
+NFSD = 2049/tcp 2049/udp
+NETFLOW = 2056/udp
+SQUID_PROXY = 3128/tcp
+MYSQL = 3306/tcp
+RDP = 3389/tcp
+IPSEC = 4500/udp
+POSTGRESQL = 5432/tcp
+TRACEROUTE = 33434-33534/udp
+
+

--- a/tests/plugins/tasks/text/test_data/nornir.pol
+++ b/tests/plugins/tasks/text/test_data/nornir.pol
@@ -1,0 +1,37 @@
+header {
+  comment:: "Sample multitarget loopback filter"
+  target:: juniper LOOPBACK
+  target:: arista LOOPBACK
+  target:: ciscoxr LOOPBACK
+}
+
+term accept-icmp {
+  protocol:: icmp
+  counter:: icmp-loopback
+  policer:: rate-limit-icmp
+  action:: accept
+}
+
+term accept-traceroute {
+  comment:: "Allow inbound traceroute from any source."
+  destination-port:: TRACEROUTE
+  protocol:: udp
+  counter:: inbound-traceroute
+  policer:: rate-limit-to-router
+  action:: accept
+  expiration:: 2021-12-31
+  owner:: jeff
+}
+
+term accept-ospf {
+  comment:: "Allow outbound OSPF traffic from other RFC1918 routers."
+  source-address:: INTERNAL
+  protocol:: ospf
+  counter:: ospf
+  action:: accept
+}
+
+term discard-default {
+  counter:: discard-default
+  action:: deny
+}


### PR DESCRIPTION
This PR adds a Nornir task plugin for utilizing [Capirca](https://github.com/google/capirca) to generate per-host ACLs. Upon success, the rendered ACL is returned as a string in the result field of a `Result`. For an ACL to be rendered, the plugin must be passed a valid capirca platform type and the host platform must be a target in the specified policy file:
```
header {
  comment:: "Sample multitarget loopback filter"
  target:: juniper LOOPBACK
  target:: arista LOOPBACK
  target:: ciscoxr LOOPBACK
}
```
This platform value is different than the top-level platform inventory field, as the existing inventory values (i.e. junos) didn't map 1:1 to capirca platforms, and maintaining a translation map seemed implicitly terrible. Therefore, the capirca platform type must be explicitly passed but can be included as inventory data as below and passed at task runtime:
```
dev4.group_2:
    data:
        capirca:
            platform: juniper
            expiration: 2
            shade_check: true
            optimize: true
```

The application dependency of Capirca v1.122/latest was left off this PR per the contributing guidelines. Please let me know if you want it added here, in a separate PR or if you will handle it. 

Also, if there is value, I'm happy to add this as a Nornir function as well, which would most likely render and write ACLs to a specified directory, much like the current Capirca toolchain.