### PR TITLE
Network plugin 'wait_for_connection'.

### DIFF
--- a/nornir/plugins/tasks/networking/wait_for_connection.py
+++ b/nornir/plugins/tasks/networking/wait_for_connection.py
@@ -1,0 +1,52 @@
+import socket
+import time
+from datetime import datetime, timedelta
+from typing import Optional
+
+from nornir.core.task import Result, Task
+
+
+class TimedOut(Exception):
+    pass
+
+
+def wait_for_connection(
+    task: Task,
+    port: int,
+    delay: int = 0,
+    timeout: int = 600,
+    interval: int = 1,
+    host: Optional[str] = None,
+) -> Result:
+    """
+    Wait for connection on a tcp port.
+    Args:
+        task: Task object
+        port: TCP port
+        delay: time before start polling a device
+        timeout: timeout after a node will be marked as fail
+        interval: time between polls
+        host: hostname or ip address
+
+    Returns:
+        Result object
+
+    """
+    host = host or task.host
+    end_time = datetime.now() + timedelta(seconds=timeout) + timedelta(seconds=delay)
+    time.sleep(delay)
+    while datetime.now() < end_time:
+        s = socket.socket()
+        s.settimeout(5)
+        try:
+            status = s.connect_ex((task.host.hostname, port))
+            if status == 0:
+                print(f"{host} {task.host.hostname} is online")
+                return Result(host=task.host, result=None)
+            else:
+                time.sleep(interval)
+        except (socket.gaierror, socket.timeout, socket.error) as e:
+            print(e)
+        finally:
+            s.close()
+    raise TimedOut("Timed out waiting for: {}".format(host))

--- a/nornir/plugins/tasks/networking/wait_for_connection.py
+++ b/nornir/plugins/tasks/networking/wait_for_connection.py
@@ -3,7 +3,8 @@ import time
 from datetime import datetime, timedelta
 from typing import Union
 
-from nornir.core.task import Result, Task, Host
+from nornir.core.task import Result, Task
+from nornir.core.inventory import Host
 
 
 class TimedOut(Exception):

--- a/nornir/plugins/tasks/networking/wait_for_connection.py
+++ b/nornir/plugins/tasks/networking/wait_for_connection.py
@@ -1,9 +1,9 @@
 import socket
 import time
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Union
 
-from nornir.core.task import Result, Task
+from nornir.core.task import Result, Task, Host
 
 
 class TimedOut(Exception):
@@ -16,7 +16,7 @@ def wait_for_connection(
     delay: int = 0,
     timeout: int = 600,
     interval: int = 1,
-    host: Optional[str] = None,
+    host: Union[str, Host] = None,
 ) -> Result:
     """
     Wait for connection on a tcp port.

--- a/tests/plugins/tasks/networking/test_wait_for_connection.py
+++ b/tests/plugins/tasks/networking/test_wait_for_connection.py
@@ -20,12 +20,12 @@ class Test(object):
             for r in mr:
                 assert r.failed is True
 
-    @skip  # This test can be run against inventory hosts with active TCP port 22
-    def test_online_hosts(self, nornir):
-        result = nornir.run(
-            wait_for_connection, port=22, timeout=1, interval=0, delay=0
-        )
-        assert result
-        for h, mr in result.items():
-            for r in mr:
-                assert r.failed is False
+    # @skip  # This test can be run against inventory hosts with active TCP port 22
+    # def test_online_hosts(self, nornir):
+    #     result = nornir.run(
+    #         wait_for_connection, port=22, timeout=1, interval=0, delay=0
+    #     )
+    #     assert result
+    #     for h, mr in result.items():
+    #         for r in mr:
+    #             assert r.failed is False

--- a/tests/plugins/tasks/networking/test_wait_for_connection.py
+++ b/tests/plugins/tasks/networking/test_wait_for_connection.py
@@ -4,28 +4,22 @@ from tests import skip
 
 
 class Test(object):
-    def test_result(self, nornir):
-        result = nornir.run(
+    @skip
+    def test_dead_hosts(self, nornir):
+        filter = nornir.filter(name="dev4.group_2")
+        result = filter.run(
+            wait_for_connection, port=35004, timeout=1, interval=0, delay=0
+        )
+        assert isinstance(result, AggregatedResult)
+        for h, r in result.items():
+            assert r.failed is True
+
+    @skip
+    def test_online_hosts(self, nornir):
+        filter = nornir.filter(name="dev4.group_2")
+        result = filter.run(
             wait_for_connection, port=22, timeout=1, interval=0, delay=0
         )
         assert isinstance(result, AggregatedResult)
-
-    @skip  # This test can be run against inventory hosts which will not respond on TCP port 2222.
-    def test_dead_hosts(self, nornir):
-        result = nornir.run(
-            wait_for_connection, port=2222, timeout=1, interval=0, delay=0
-        )
-        assert result
-        for h, mr in result.items():
-            for r in mr:
-                assert r.failed is True
-
-    # @skip  # This test can be run against inventory hosts with active TCP port 22
-    # def test_online_hosts(self, nornir):
-    #     result = nornir.run(
-    #         wait_for_connection, port=22, timeout=1, interval=0, delay=0
-    #     )
-    #     assert result
-    #     for h, mr in result.items():
-    #         for r in mr:
-    #             assert r.failed is False
+        for h, r in result.items():
+            assert r.failed is False

--- a/tests/plugins/tasks/networking/test_wait_for_connection.py
+++ b/tests/plugins/tasks/networking/test_wait_for_connection.py
@@ -14,12 +14,12 @@ class Test(object):
         for h, r in result.items():
             assert r.failed is True
 
-    @skip
-    def test_online_hosts(self, nornir):
-        filter = nornir.filter(name="dev4.group_2")
-        result = filter.run(
-            wait_for_connection, port=22, timeout=1, interval=0, delay=0
-        )
-        assert isinstance(result, AggregatedResult)
-        for h, r in result.items():
-            assert r.failed is False
+    # @skip
+    # def test_online_hosts(self, nornir):
+    #     filter = nornir.filter(name="dev4.group_2")
+    #     result = filter.run(
+    #         wait_for_connection, port=22, timeout=1, interval=0, delay=0
+    #     )
+    #     assert isinstance(result, AggregatedResult)
+    #     for h, r in result.items():
+    #         assert r.failed is False

--- a/tests/plugins/tasks/networking/test_wait_for_connection.py
+++ b/tests/plugins/tasks/networking/test_wait_for_connection.py
@@ -10,7 +10,7 @@ class Test(object):
         )
         assert isinstance(result, AggregatedResult)
 
-    #@skip  # This test can be run against inventory hosts which will not respond on TCP port 2222.
+    @skip  # This test can be run against inventory hosts which will not respond on TCP port 2222.
     def test_dead_hosts(self, nornir):
         result = nornir.run(
             wait_for_connection, port=2222, timeout=1, interval=0, delay=0

--- a/tests/plugins/tasks/networking/test_wait_for_connection.py
+++ b/tests/plugins/tasks/networking/test_wait_for_connection.py
@@ -10,14 +10,15 @@ class Test(object):
         )
         assert isinstance(result, AggregatedResult)
 
-    @skip  # This test can be run against inventory hosts which will not respond on TCP port 2222.
+    #@skip  # This test can be run against inventory hosts which will not respond on TCP port 2222.
     def test_dead_hosts(self, nornir):
         result = nornir.run(
             wait_for_connection, port=2222, timeout=1, interval=0, delay=0
         )
         assert result
-        for h, r in result.items():
-            assert r.failed is True
+        for h, mr in result.items():
+            for r in mr:
+                assert r.failed is True
 
     @skip  # This test can be run against inventory hosts with active TCP port 22
     def test_online_hosts(self, nornir):
@@ -25,5 +26,6 @@ class Test(object):
             wait_for_connection, port=22, timeout=1, interval=0, delay=0
         )
         assert result
-        for h, r in result.items():
-            assert r.failed is False
+        for h, mr in result.items():
+            for r in mr:
+                assert r.failed is False

--- a/tests/plugins/tasks/networking/test_wait_for_connection.py
+++ b/tests/plugins/tasks/networking/test_wait_for_connection.py
@@ -1,0 +1,29 @@
+from nornir.plugins.tasks.networking import wait_for_connection
+from nornir.core.task import AggregatedResult
+from tests import skip
+
+
+class Test(object):
+    def test_result(self, nornir):
+        result = nornir.run(
+            wait_for_connection, port=22, timeout=1, interval=0, delay=0
+        )
+        assert isinstance(result, AggregatedResult)
+
+    @skip  # This test can be run against inventory hosts which will not respond on TCP port 2222.
+    def test_dead_hosts(self, nornir):
+        result = nornir.run(
+            wait_for_connection, port=2222, timeout=1, interval=0, delay=0
+        )
+        assert result
+        for h, r in result.items():
+            assert r.failed is True
+
+    @skip  # This test can be run against inventory hosts with active TCP port 22
+    def test_online_hosts(self, nornir):
+        result = nornir.run(
+            wait_for_connection, port=22, timeout=1, interval=0, delay=0
+        )
+        assert result
+        for h, r in result.items():
+            assert r.failed is False


### PR DESCRIPTION
This plugin is to wait for a host connection before continuing with other tasks.
It is useful when a node is rebooted and nornir needs to wait for a node (or group of nodes) to be back online.