### PR TITLE
Do not store failed connections in host attributes

### DIFF
--- a/nornir/core/connections.py
+++ b/nornir/core/connections.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, NoReturn, Optional, Type
+from typing import Any, Dict, Optional, Type
 
 
 from nornir.core.configuration import Config
@@ -7,6 +7,8 @@ from nornir.core.exceptions import (
     ConnectionPluginAlreadyRegistered,
     ConnectionPluginNotRegistered,
 )
+
+UNESTABLISHED_CONNECTION = object()
 
 
 class ConnectionPlugin(ABC):
@@ -23,7 +25,7 @@ class ConnectionPlugin(ABC):
     __slots__ = ("connection", "state")
 
     def __init__(self) -> None:
-        self.connection: Any = UnestablishedConnection()
+        self.connection: Any = UNESTABLISHED_CONNECTION
         self.state: Dict[str, Any] = {}
 
     @abstractmethod
@@ -47,13 +49,6 @@ class ConnectionPlugin(ABC):
     def close(self) -> None:
         """Close the connection with the device"""
         pass
-
-
-class UnestablishedConnection(object):
-    def close(self) -> NoReturn:
-        raise ValueError("Connection not established")
-
-    disconnect = close
 
 
 class Connections(Dict[str, ConnectionPlugin]):

--- a/nornir/core/connections.py
+++ b/nornir/core/connections.py
@@ -8,8 +8,6 @@ from nornir.core.exceptions import (
     ConnectionPluginNotRegistered,
 )
 
-UNESTABLISHED_CONNECTION = object()
-
 
 class ConnectionPlugin(ABC):
     """
@@ -25,7 +23,7 @@ class ConnectionPlugin(ABC):
     __slots__ = ("connection", "state")
 
     def __init__(self) -> None:
-        self.connection: Any = UNESTABLISHED_CONNECTION
+        self.connection: Any = None
         self.state: Dict[str, Any] = {}
 
     @abstractmethod

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -7,7 +7,6 @@ from nornir.core.configuration import Config
 from nornir.core.connections import (
     ConnectionPlugin,
     Connections,
-    UNESTABLISHED_CONNECTION,
 )
 from nornir.core.exceptions import ConnectionAlreadyOpen, ConnectionNotOpen
 
@@ -342,7 +341,7 @@ class Host(InventoryElement):
         """
         conn_name = connection
         existing_conn = self.connections.get(conn_name)
-        if existing_conn is not None and existing_conn is not UNESTABLISHED_CONNECTION:
+        if existing_conn is not None:
             raise ConnectionAlreadyOpen(conn_name)
 
         plugin = self.connections.get_plugin(conn_name)
@@ -374,9 +373,9 @@ class Host(InventoryElement):
         if conn_name not in self.connections:
             raise ConnectionNotOpen(conn_name)
 
-        connection = self.connections.pop(conn_name)
-        if connection is not UNESTABLISHED_CONNECTION:
-            connection.close()
+        conn_obj = self.connections.pop(conn_name)
+        if conn_obj is not None:
+            conn_obj.close()
 
     def close_connections(self) -> None:
         # Decouple deleting dictionary elements from iterating over connections dict

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, List, Optional, Set, Union
 
 from nornir.core import deserializer
 from nornir.core.configuration import Config
-from nornir.core.connections import ConnectionPlugin, Connections
+from nornir.core.connections import (
+    ConnectionPlugin,
+    Connections,
+    UNESTABLISHED_CONNECTION,
+)
 from nornir.core.exceptions import ConnectionAlreadyOpen, ConnectionNotOpen
 
 
@@ -336,39 +340,43 @@ class Host(InventoryElement):
         Returns:
             An already established connection
         """
-        if connection in self.connections:
-            raise ConnectionAlreadyOpen(connection)
+        conn_name = connection
+        existing_conn = self.connections.get(conn_name)
+        if existing_conn is not None and existing_conn is not UNESTABLISHED_CONNECTION:
+            raise ConnectionAlreadyOpen(conn_name)
 
-        self.connections[connection] = self.connections.get_plugin(connection)()
+        plugin = self.connections.get_plugin(conn_name)
+        conn_obj = plugin()
         if default_to_host_attributes:
-            conn_params = self.get_connection_parameters(connection)
-            self.connections[connection].open(
-                hostname=hostname if hostname is not None else conn_params.hostname,
-                username=username if username is not None else conn_params.username,
-                password=password if password is not None else conn_params.password,
-                port=port if port is not None else conn_params.port,
-                platform=platform if platform is not None else conn_params.platform,
-                extras=extras if extras is not None else conn_params.extras,
-                configuration=configuration,
-            )
-        else:
-            self.connections[connection].open(
-                hostname=hostname,
-                username=username,
-                password=password,
-                port=port,
-                platform=platform,
-                extras=extras,
-                configuration=configuration,
-            )
-        return self.connections[connection]
+            conn_params = self.get_connection_parameters(conn_name)
+            hostname = hostname if hostname is not None else conn_params.hostname
+            username = username if username is not None else conn_params.username
+            password = password if password is not None else conn_params.password
+            port = port if port is not None else conn_params.port
+            platform = platform if platform is not None else conn_params.platform
+            extras = extras if extras is not None else conn_params.extras
+
+        conn_obj.open(
+            hostname=hostname,
+            username=username,
+            password=password,
+            port=port,
+            platform=platform,
+            extras=extras,
+            configuration=configuration,
+        )
+        self.connections[conn_name] = conn_obj
+        return connection
 
     def close_connection(self, connection: str) -> None:
         """ Close the connection"""
-        if connection not in self.connections:
-            raise ConnectionNotOpen(connection)
+        conn_name = connection
+        if conn_name not in self.connections:
+            raise ConnectionNotOpen(conn_name)
 
-        self.connections.pop(connection).close()
+        connection = self.connections.pop(conn_name)
+        if connection is not UNESTABLISHED_CONNECTION:
+            connection.close()
 
     def close_connections(self) -> None:
         # Decouple deleting dictionary elements from iterating over connections dict


### PR DESCRIPTION
With this fix failed connections are not stored in `host.connections` dictionary, which means we are not trying to close them, raising an exception.
Besides fixing bug #350, this also now allows to have a transparent retry mechanism for tasks which work with connections. Previously, any retry on the host, connection to which has failed, would leave a connection attribute uninitialized and ultimately fail.