### PR TITLE
Improved whitespace handling in jinja template rendering

### DIFF
--- a/nornir/core/helpers/jinja_helper.py
+++ b/nornir/core/helpers/jinja_helper.py
@@ -11,7 +11,11 @@ def render_from_file(
 ) -> str:
     jinja_filters = jinja_filters or {}
     env = Environment(
-        loader=FileSystemLoader(path), undefined=StrictUndefined, trim_blocks=True
+        loader=FileSystemLoader(path),
+        undefined=StrictUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
     )
     env.filters.update(jinja_filters)
     t = env.get_template(template)

--- a/nornir/core/helpers/jinja_helper.py
+++ b/nornir/core/helpers/jinja_helper.py
@@ -7,31 +7,34 @@ def render_from_file(
     path: str,
     template: str,
     jinja_filters: Optional[Dict[str, Any]] = None,
+    jinja_env: Optional[Environment] = None,
     **kwargs: Any
 ) -> str:
     jinja_filters = jinja_filters or {}
-    env = Environment(
-        loader=FileSystemLoader(path),
-        undefined=StrictUndefined,
-        trim_blocks=True,
-        lstrip_blocks=True,
-        keep_trailing_newline=True,
-    )
+    if jinja_env:
+        env = jinja_env
+        env.loader = FileSystemLoader(path)
+    else:
+        env = Environment(
+            loader=FileSystemLoader(path), undefined=StrictUndefined, trim_blocks=True,
+        )
     env.filters.update(jinja_filters)
     t = env.get_template(template)
     return t.render(**kwargs)
 
 
 def render_from_string(
-    template: str, jinja_filters: Optional[Dict[str, Any]] = None, **kwargs: Any
+    template: str,
+    jinja_filters: Optional[Dict[str, Any]] = None,
+    jinja_env: Optional[Environment] = None,
+    **kwargs: Any
 ) -> str:
     jinja_filters = jinja_filters or {}
-    env = Environment(
-        undefined=StrictUndefined,
-        trim_blocks=True,
-        lstrip_blocks=True,
-        keep_trailing_newline=True,
-    )
+    if jinja_env:
+        env = jinja_env
+        env.loader = FileSystemLoader(path)
+    else:
+        env = Environment(undefined=StrictUndefined, trim_blocks=True,)
     env.filters.update(jinja_filters)
     t = env.from_string(template)
     return t.render(**kwargs)

--- a/nornir/core/helpers/jinja_helper.py
+++ b/nornir/core/helpers/jinja_helper.py
@@ -32,7 +32,6 @@ def render_from_string(
     jinja_filters = jinja_filters or {}
     if jinja_env:
         env = jinja_env
-        env.loader = FileSystemLoader(path)
     else:
         env = Environment(undefined=StrictUndefined, trim_blocks=True,)
     env.filters.update(jinja_filters)

--- a/nornir/core/helpers/jinja_helper.py
+++ b/nornir/core/helpers/jinja_helper.py
@@ -26,7 +26,12 @@ def render_from_string(
     template: str, jinja_filters: Optional[Dict[str, Any]] = None, **kwargs: Any
 ) -> str:
     jinja_filters = jinja_filters or {}
-    env = Environment(undefined=StrictUndefined, trim_blocks=True)
+    env = Environment(
+        undefined=StrictUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+    )
     env.filters.update(jinja_filters)
     t = env.from_string(template)
     return t.render(**kwargs)


### PR DESCRIPTION
When developing jinja templates for use with Nornir I've run in to two issues that I think we can solve by adjusting the jinja environment for template rendering.

1. If the template includes several blocks that are indented, the output also gets a strange indent. Ex:
```
{% for loop1 %}
  {% if statement1 %}
    {% if statement2 %}
 description {{ description }}
```
All those whitespace before the {%%} blocks seems to be compounded and added before the description line, which makes it's indent look really weird in the output. If we add lstrip_blocks=True those whitespace to the left will be removed.

2. When including several files the removal of trailing whitespace might cause issues. Ex:
```
{% include 'vlan.j2' %}
{% include 'vrf.j2' %}
```
The trailing newline from the file vlan.j2 will be removed causing the last line of vlan.j2 and the first line of vrf.j2 to end up on the same line. This might not be an issue when rendering HTML templates or something but for CLI config it's annoying which is why I suggest we change the defaults.

I don't see any big disadvantage in changing these defaults for the type of config rendering that's done in Nornir, but if there are maybe this should be configurable somehow instead.