### PR TITLE
NBInventory - adds device name if no primary IP

### DIFF
--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -65,7 +65,7 @@ class NBInventory(Inventory):
             if d.get("primary_ip", {}):
                 host["hostname"] = d["primary_ip"]["address"].split("/")[0]
             else:
-                # Set to the hostname in NetBox if there is not a primary IP, that DNS will be in place
+                # Set to the hostname in NetBox if not a primary IP, expect DNS will be in place
                 host["hostname"] = d.get("name")
 
             # Add values that don't have an option for 'slug'

--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -22,9 +22,9 @@ class NBInventory(Inventory):
         Netbox plugin
 
         Arguments:
-            nb_url: Netbox url, defaults to http://localhost:8080.
+            nb_url: NetBox url, defaults to http://localhost:8080.
                 You can also use env variable NB_URL
-            nb_token: Netbokx token. You can also use env variable NB_TOKEN
+            nb_token: NetbBox token. You can also use env variable NB_TOKEN
             use_slugs: Whether to use slugs or not
             ssl_verify: Enable/disable certificate validation or provide path to CA bundle file
             flatten_custom_fields: Whether to assign custom fields directly to the host or not
@@ -64,6 +64,9 @@ class NBInventory(Inventory):
             # Add value for IP address
             if d.get("primary_ip", {}):
                 host["hostname"] = d["primary_ip"]["address"].split("/")[0]
+            else:
+                # Set to the hostname in NetBox if there is not a primary IP, that DNS will be in place
+                host["hostname"] = d.get("name")
 
             # Add values that don't have an option for 'slug'
             host["data"]["serial"] = d["serial"]

--- a/nornir/plugins/inventory/netbox.py
+++ b/nornir/plugins/inventory/netbox.py
@@ -66,7 +66,8 @@ class NBInventory(Inventory):
                 host["hostname"] = d["primary_ip"]["address"].split("/")[0]
             else:
                 # Set to the hostname in NetBox if not a primary IP, expect DNS will be in place
-                host["hostname"] = d.get("name")
+                if d.get("name") is not None:
+                    host["hostname"] = d["name"]
 
             # Add values that don't have an option for 'slug'
             host["data"]["serial"] = d["serial"]


### PR DESCRIPTION
- Updates NetBox name in docs
- Adds else statement to use device name if there is not a primary IP address

Fixes the NetBox plugin around issue 289, but not the rest of the plugins