### PR TITLE
proposal for runners

### DIFF
--- a/docs/upgrading/2_to_3.rst
+++ b/docs/upgrading/2_to_3.rst
@@ -32,7 +32,7 @@ InitNornir
 Configuration
 =============
 
-1. Order of resolution is now file -> paramters to InitNornir -> env var
+1. Order of resolution is parameters to InitNornit > config > env
 
 Todo
 ----

--- a/nornir/core/plugins/runners.py
+++ b/nornir/core/plugins/runners.py
@@ -1,0 +1,29 @@
+from typing import Any, List, Type
+
+from nornir.core.task import AggregatedResult, Task
+from nornir.core.inventory import Host
+from nornir.core.plugins.register import PluginRegister
+
+from typing_extensions import Protocol
+
+
+RUNNERS_PLUGIN_PATH = "nornir.plugins.runners"
+
+
+class RunnerPlugin(Protocol):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+    def run(self, task: Task, hosts: List[Host]) -> AggregatedResult:
+        """
+        This method runs the given task over all the hosts
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+
+RunnersPluginRegister: PluginRegister[Type[RunnerPlugin]] = PluginRegister(
+    RUNNERS_PLUGIN_PATH
+)

--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -9,6 +9,7 @@ from nornir.core.plugins.inventory import (
     InventoryPluginRegister,
     TransformFunctionRegister,
 )
+from nornir.core.plugins.runners import RunnerPlugin, RunnersPluginRegister
 from nornir.core.state import GlobalState
 
 
@@ -36,6 +37,13 @@ def load_inventory(config: Config,) -> Inventory:
     return inv
 
 
+def load_runner(config: Config,) -> RunnerPlugin:
+    RunnersPluginRegister.auto_register()
+    runner_plugin = RunnersPluginRegister.get_plugin(config.runner.plugin)
+    runner = runner_plugin(**config.runner.options)
+    return runner
+
+
 def InitNornir(config_file: str = "", dry_run: bool = False, **kwargs: Any,) -> Nornir:
     """
     Arguments:
@@ -61,4 +69,9 @@ def InitNornir(config_file: str = "", dry_run: bool = False, **kwargs: Any,) -> 
 
     config.logging.configure()
 
-    return Nornir(inventory=load_inventory(config), config=config, data=data,)
+    return Nornir(
+        inventory=load_inventory(config),
+        runner=load_runner(config),
+        config=config,
+        data=data,
+    )

--- a/nornir/plugins/runners/__init__.py
+++ b/nornir/plugins/runners/__init__.py
@@ -1,0 +1,45 @@
+from typing import List
+from concurrent.futures import ThreadPoolExecutor
+
+from nornir.core.task import AggregatedResult, Task
+from nornir.core.inventory import Host
+
+
+class SerialRunner:
+    """
+    SerialRunner runs the task over each host one after the other without any parellelization
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def run(self, task: Task, hosts: List[Host]) -> AggregatedResult:
+        result = AggregatedResult(task.name)
+        for host in hosts:
+            result[host.name] = task.copy().start(host)
+        return result
+
+
+class ParallelRunner:
+    """
+    ParallelRunner runs the task over each host using threads
+
+    Arguments:
+        num_workers: number of threads to use
+    """
+
+    def __init__(self, num_workers: int = 20) -> None:
+        self.num_workers = num_workers
+
+    def run(self, task: Task, hosts: List[Host]) -> AggregatedResult:
+        result = AggregatedResult(task.name)
+        futures = []
+        with ThreadPoolExecutor(self.num_workers) as pool:
+            for host in hosts:
+                future = pool.submit(task.copy().start, host)
+                futures.append(future)
+
+        for future in futures:
+            worker_result = future.result()
+            result[worker_result.host.name] = worker_result
+        return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
+[tool.poetry.plugins."nornir.plugins.runners"]
+"serial" = "nornir.plugins.runners:SerialRunner"
+"parallel" = "nornir.plugins.runners:ParallelRunner"
+
 [tool.poetry]
 name = "nornir"
 version = "3.0.0a2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,11 +49,5 @@ warn_redundant_casts = True
 [mypy-nornir.core]
 ignore_errors = True
 
-[mypy-nornir.core.deserializer.configuration]
-ignore_errors = True
-
 [mypy-tests.*]
-ignore_errors = True
-
-[mypy-nornir._vendor.*]
 ignore_errors = True

--- a/tests/core/test_InitNornir.py
+++ b/tests/core/test_InitNornir.py
@@ -71,20 +71,19 @@ class Test(object):
         nr = InitNornir(inventory={"plugin": "inventory-test"})
         os.chdir("../../")
         assert not nr.data.dry_run
-        assert nr.config.core.num_workers == 20
+        assert not nr.config.core.raise_on_error
         assert len(nr.inventory.hosts)
         assert len(nr.inventory.groups)
 
     def test_InitNornir_file(self):
         nr = InitNornir(config_file=os.path.join(dir_path, "a_config.yaml"))
         assert not nr.data.dry_run
-        assert nr.config.core.num_workers == 100
         assert len(nr.inventory.hosts)
         assert len(nr.inventory.groups)
 
     def test_InitNornir_programmatically(self):
         nr = InitNornir(
-            core={"num_workers": 100},
+            core={"raise_on_error": True},
             inventory={
                 "plugin": "inventory-test",
                 "options": {
@@ -94,7 +93,7 @@ class Test(object):
             },
         )
         assert not nr.data.dry_run
-        assert nr.config.core.num_workers == 100
+        assert nr.config.core.raise_on_error
         assert len(nr.inventory.hosts)
         assert len(nr.inventory.groups)
 
@@ -103,16 +102,15 @@ class Test(object):
             config_file=os.path.join(dir_path, "a_config.yaml"),
             core={"raise_on_error": True},
         )
-        assert nr.config.core.num_workers == 100
         assert nr.config.core.raise_on_error
 
     def test_InitNornir_combined(self):
         nr = InitNornir(
             config_file=os.path.join(dir_path, "a_config.yaml"),
-            core={"num_workers": 200},
+            core={"raise_on_error": True},
         )
         assert not nr.data.dry_run
-        assert nr.config.core.num_workers == 200
+        assert nr.config.core.raise_on_error
         assert len(nr.inventory.hosts)
         assert len(nr.inventory.groups)
 
@@ -187,10 +185,7 @@ class TestLogging:
 
     def test_InitNornir_logging_defaults(self):
         self.cleanup()
-        InitNornir(
-            config_file=os.path.join(dir_path, "a_config.yaml"),
-            core={"num_workers": 200},
-        )
+        InitNornir(config_file=os.path.join(dir_path, "a_config.yaml"),)
         nornir_logger = logging.getLogger("nornir")
 
         assert nornir_logger.level == logging.INFO

--- a/tests/core/test_InitNornir/a_config.yaml
+++ b/tests/core/test_InitNornir/a_config.yaml
@@ -1,6 +1,6 @@
 ---
 core:
-    num_workers: 100
+    raise_on_error: true
 inventory:
     plugin: "inventory-test"
     options:

--- a/tests/core/test_configuration/config.yaml
+++ b/tests/core/test_configuration/config.yaml
@@ -1,6 +1,5 @@
 ---
 core:
-    num_workers: 10
     raise_on_error: false
 inventory:
     plugin: tests.core.deserializer.test_configuration.DummyInventory

--- a/tests/core/test_tasks.py
+++ b/tests/core/test_tasks.py
@@ -119,7 +119,6 @@ class Test(object):
             sub_task_for_testing_overrides_severity,
             fail_on=["dev3.group_2"],
             severity_level=logging.WARN,
-            num_workers=1,
         )
         for host, result in r.items():
             if host == "dev3.group_2":

--- a/tests/plugins/processors/test_serial.py
+++ b/tests/plugins/processors/test_serial.py
@@ -1,0 +1,52 @@
+import datetime
+import time
+
+from nornir.plugins.runners import SerialRunner
+
+
+class CustomException(Exception):
+    pass
+
+
+def a_task_for_testing(task, command):
+    if command == "failme":
+        raise CustomException()
+
+
+def blocking_task(task, wait):
+    time.sleep(wait)
+
+
+def failing_task_simple(task):
+    raise Exception(task.host.name)
+
+
+def failing_task_complex(task):
+    a_task_for_testing(task, command="failme")
+
+
+class TestSerialRunner(object):
+    def test_blocking_task_single_thread(self, nornir):
+        t1 = datetime.datetime.now()
+        nornir.with_runner(SerialRunner()).run(blocking_task, wait=0.5)
+        t2 = datetime.datetime.now()
+        delta = t2 - t1
+        assert delta.seconds == 2, delta
+
+    def test_failing_task_simple_singlethread(self, nornir):
+        result = nornir.with_runner(SerialRunner()).run(failing_task_simple)
+        processed = False
+        for k, v in result.items():
+            processed = True
+            assert isinstance(k, str), k
+            assert isinstance(v.exception, Exception), v
+        assert processed
+
+    def test_failing_task_complex_singlethread(self, nornir):
+        result = nornir.with_runner(SerialRunner()).run(failing_task_complex)
+        processed = False
+        for k, v in result.items():
+            processed = True
+            assert isinstance(k, str), k
+            assert isinstance(v.exception, CustomException), v
+        assert processed


### PR DESCRIPTION
This PR introduces the concept of runners. Prior to this PR the only way to control the execution was via `num_workers` which basically toggled between using threads or not and configured how many threads to use if workers was greater than 1. With this proposal we can write plugins that act as a "runner", a piece of code that distributes the task across the hosts.

Writing a runner is fairly straightforward (or complex, depending of what you want to do). As an example, the runner that implements parallelization as before is this:

``` python

class ParallelRunner:
    """
    ParallelRunner runs the task over each host using threads

    Arguments:
        num_workers: number of threads to use
    """

    def __init__(self, num_workers: int = 20) -> None:
        self.num_workers = num_workers

    def run(self, task: Task, hosts: List[Host]) -> AggregatedResult:
        result = AggregatedResult(task.name)
        futures = []
        with ThreadPoolExecutor(self.num_workers) as pool:
            for host in hosts:
                future = pool.submit(task.copy().start, host)
                futures.append(future)

        for future in futures:
            worker_result = future.result()
            result[worker_result.host.name] = worker_result
        return result
```

The API to use them is slightly different, `num_workers` is no longer available to `nr.run`, instead you can configure the runner with the configuration and/or override it with `nr.with_runner`:

``` python
# use what's set previously or by the configuration, same default as before
nr.run(...) 

# override for this run
nr.with_runner(ParallelRunner(num_workers=100)).run(...)

# set a new runner for a new nornir object
nr_new_runner = nr.with_runner(ParallelRunner(num_workers=100)) 
```

The equivalent of `nr.run(num_workers=1)` now would be:

``` python
nr.with_runner(SerialRunner()).run(...)
```

### Another example

If you wanted to write a runner that run the task over the hosts in alphabetical order and without threads, you could do something like:


``` python
def host_key(host):
    return host.name

class OCDRunner:
    def __init__(self, reverse: bool=False) -> None:
        self.reverse = reverse

    def run(self, task: Task, hosts: List[Host]) -> AggregatedResult:
        result = AggregatedResult(task.name)
        for hostname, host in sorted(hosts, key=host_key, reverse=self.reverse):
            result[host.name] = task.copy().start(host)
        return result
```

and then set it in the configuration like this:

``` yaml
runner:
    # plugin needs to be registered though, more on this in a more elaborate howto
    plugin: OCDRunner
    options:
         reverse: true
```

or:

``` python
nr.with_runner(OCDRunner(reverse=True)).run(...)
```

### Todo

1. Add to the tutorial
2. Write a more detailed how to