### PR TITLE
Default to SimpleInventory if no inventory plugin in specified (nornir3.0)

### DIFF
--- a/nornir/core/configuration.py
+++ b/nornir/core/configuration.py
@@ -73,7 +73,7 @@ class InventoryConfig(object):
     __slots__ = "plugin", "options", "transform_function", "transform_function_options"
 
     class Parameters:
-        plugin = Parameter(typ=str, envvar="NORNIR_INVENTORY_PLUGIN")
+        plugin = Parameter(typ=str, default="SimpleInventory", envvar="NORNIR_INVENTORY_PLUGIN")
         options = Parameter(default={}, envvar="NORNIR_INVENTORY_OPTIONS")
         transform_function = Parameter(
             typ=str, envvar="NORNIR_INVENTORY_TRANSFORM_FUNCTION"

--- a/nornir/core/configuration.py
+++ b/nornir/core/configuration.py
@@ -73,7 +73,9 @@ class InventoryConfig(object):
     __slots__ = "plugin", "options", "transform_function", "transform_function_options"
 
     class Parameters:
-        plugin = Parameter(typ=str, default="SimpleInventory", envvar="NORNIR_INVENTORY_PLUGIN")
+        plugin = Parameter(
+            typ=str, default="SimpleInventory", envvar="NORNIR_INVENTORY_PLUGIN"
+        )
         options = Parameter(default={}, envvar="NORNIR_INVENTORY_OPTIONS")
         transform_function = Parameter(
             typ=str, envvar="NORNIR_INVENTORY_TRANSFORM_FUNCTION"

--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -24,9 +24,7 @@ def register_default_connection_plugins() -> None:
 
 def load_inventory(config: Config,) -> Inventory:
     InventoryPluginRegister.auto_register()
-    inventory_plugin = InventoryPluginRegister.get_plugin(
-        config.inventory.plugin or "SimpleInventory"
-    )
+    inventory_plugin = InventoryPluginRegister.get_plugin(config.inventory.plugin)
     inv = inventory_plugin(**config.inventory.options).load()
 
     if config.inventory.transform_function:

--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -24,7 +24,7 @@ def register_default_connection_plugins() -> None:
 
 def load_inventory(config: Config,) -> Inventory:
     InventoryPluginRegister.auto_register()
-    inventory_plugin = InventoryPluginRegister.get_plugin(config.inventory.plugin or "")
+    inventory_plugin = InventoryPluginRegister.get_plugin(config.inventory.plugin or "SimpleInventory")
     inv = inventory_plugin(**config.inventory.options).load()
 
     if config.inventory.transform_function:

--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -24,7 +24,9 @@ def register_default_connection_plugins() -> None:
 
 def load_inventory(config: Config,) -> Inventory:
     InventoryPluginRegister.auto_register()
-    inventory_plugin = InventoryPluginRegister.get_plugin(config.inventory.plugin or "SimpleInventory")
+    inventory_plugin = InventoryPluginRegister.get_plugin(
+        config.inventory.plugin or "SimpleInventory"
+    )
     inv = inventory_plugin(**config.inventory.options).load()
 
     if config.inventory.transform_function:

--- a/tests/core/test_InitNornir.py
+++ b/tests/core/test_InitNornir.py
@@ -66,6 +66,13 @@ TransformFunctionRegister.register(
 
 
 class Test(object):
+    def test_InitNornir_bare(self):
+        os.chdir("tests/inventory_data/")
+        nr = InitNornir()
+        os.chdir("../../")
+        assert len(nr.inventory.hosts)
+        assert len(nr.inventory.groups)
+
     def test_InitNornir_defaults(self):
         os.chdir("tests/inventory_data/")
         nr = InitNornir(inventory={"plugin": "inventory-test"})

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -21,7 +21,7 @@ class Test(object):
             "core": {"raise_on_error": False},
             "runner": {"options": {}, "plugin": "threaded"},
             "inventory": {
-                "plugin": "",
+                "plugin": "SimpleInventory",
                 "options": {},
                 "transform_function": "",
                 "transform_function_options": {},
@@ -44,7 +44,7 @@ class Test(object):
             "core": {"raise_on_error": False},
             "runner": {"options": {}, "plugin": "threaded"},
             "inventory": {
-                "plugin": "",
+                "plugin": "SimpleInventory",
                 "options": {},
                 "transform_function": "",
                 "transform_function_options": {},


### PR DESCRIPTION
This causes a blank InitNornir() call to retain its current behavior (i.e. to default to using SimpleInventory).