### PR TITLE
Fixing simple inventory so that ~ works properly

### DIFF
--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -84,9 +84,9 @@ class SimpleInventory:
                 If it doesn't exist it will be skipped
         """
 
-        self.host_file = pathlib.Path(host_file)
-        self.group_file = pathlib.Path(group_file)
-        self.defaults_file = pathlib.Path(defaults_file)
+        self.host_file = pathlib.Path(host_file).expanduser()
+        self.group_file = pathlib.Path(group_file).expanduser()
+        self.defaults_file = pathlib.Path(defaults_file).expanduser()
 
     def load(self) -> Inventory:
         yml = ruamel.yaml.YAML(typ="safe")


### PR DESCRIPTION
Allow ~ references such as this to work properly:

```yaml
---
inventory:
  plugin: SimpleInventory
  options:
    host_file: "~/nornir_inventory/hosts.yaml"
    group_file: "~/nornir_inventory/groups.yaml"
    defaults_file: "~/nornir_inventory/defaults.yaml"
```