### PR TITLE
Nornir 3.x: Use textfsm with fix for Windows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run nbval
         run: make nbval
-        if: platform != 'windows-latest'
+        if: ${{ matrix.platform != 'windows-latest' }}
 
   release:
     name: Releasing to pypi

--- a/poetry.lock
+++ b/poetry.lock
@@ -791,11 +791,10 @@ description = "Package to return structured data from the output of network devi
 name = "ntc-templates"
 optional = false
 python-versions = "*"
-version = "1.4.1"
+version = "1.5.0"
 
 [package.dependencies]
-terminal = "*"
-textfsm = "*"
+textfsm = ">=1.1.0"
 
 [package.extras]
 dev = ["pyyaml", "black", "pytest", "ruamel.yaml", "yamllint"]
@@ -1394,14 +1393,6 @@ pywinpty = ">=0.5"
 tornado = ">=4"
 
 [[package]]
-category = "dev"
-description = "terminal\n    ~~~~~~~~\n\n    A terminal environment tools.\n\n    :copyright: (c) 2013 by Hsiaoming Yang."
-name = "terminal"
-optional = false
-python-versions = "*"
-version = "0.4.0"
-
-[[package]]
 category = "main"
 description = "Test utilities for code working with files and commands"
 name = "testpath"
@@ -1414,12 +1405,16 @@ test = ["pathlib2"]
 
 [[package]]
 category = "dev"
-description = "Python module for parsing semi-structured text into python tables."
+description = ""
 name = "textfsm"
 optional = false
 python-versions = "*"
-version = "0.4.1"
+version = "1.1.1a1"
 
+[package.source]
+reference = "30b55e037437e513e48f127cbeb56f83787aaeb5"
+type = "git"
+url = "https://github.com/ktbyers/textfsm.git"
 [[package]]
 category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -1551,7 +1546,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 docs = ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-napoleon", "jupyter", "nbsphinx", "pygments", "sphinx-issues"]
 
 [metadata]
-content-hash = "43d24fd9542bacf2c3bb67ee5e5e82c401a26493fa60a358cb4ea48fbf46e785"
+content-hash = "b604348bc6218605838374e261c03538f625329b005e75daa6e1c8d3f813f99d"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1947,8 +1942,8 @@ notebook = [
     {file = "notebook-6.0.3.tar.gz", hash = "sha256:47a9092975c9e7965ada00b9a20f0cf637d001db60d241d479f53c0be117ad48"},
 ]
 ntc-templates = [
-    {file = "ntc_templates-1.4.1-py3-none-any.whl", hash = "sha256:309fd9513301ff4855e75700b812095842e5dcad649aea8c44d391e3a4748e5a"},
-    {file = "ntc_templates-1.4.1.tar.gz", hash = "sha256:d04f859f3db2abbb1b594b4507b14551ea5d1a7724b9f4f5843326c4277f5382"},
+    {file = "ntc_templates-1.5.0-py3-none-any.whl", hash = "sha256:e234a89621f161512690b3e9fe90231795f60c26388643d1483443d58909cdb5"},
+    {file = "ntc_templates-1.5.0.tar.gz", hash = "sha256:ec4bb9e23d2e8c724613c699cd9a7413c22d02ff73a47868b970e24904f9d483"},
 ]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
@@ -2250,16 +2245,11 @@ terminado = [
     {file = "terminado-0.8.3-py2.py3-none-any.whl", hash = "sha256:a43dcb3e353bc680dd0783b1d9c3fc28d529f190bc54ba9a229f72fe6e7a54d7"},
     {file = "terminado-0.8.3.tar.gz", hash = "sha256:4804a774f802306a7d9af7322193c5390f1da0abb429e082a10ef1d46e6fb2c2"},
 ]
-terminal = [
-    {file = "terminal-0.4.0.tar.gz", hash = "sha256:29a1696ed4696a9c3e501076245c85a3789548db708bb2bd174dcc49f2b585c2"},
-]
 testpath = [
     {file = "testpath-0.4.4-py2.py3-none-any.whl", hash = "sha256:bfcf9411ef4bf3db7579063e0546938b1edda3d69f4e1fb8756991f5951f85d4"},
     {file = "testpath-0.4.4.tar.gz", hash = "sha256:60e0a3261c149755f4399a1fff7d37523179a70fdc3abdf78de9fc2604aeec7e"},
 ]
-textfsm = [
-    {file = "textfsm-0.4.1.tar.gz", hash = "sha256:21a31e212d625d84a8c7a52f35055d536bd3a1c63d3d41ed65ee5d8bd5f29f00"},
-]
+textfsm = []
 toml = [
     {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ sphinx-issues = "^1.2"
 nornir_utils = { version = "*" }
 nornir_jinja2 = { version = "*" }
 nornir-napalm = { version = "*" }
-textfsm = "0.4.1" # due to https://github.com/google/textfsm/issues/63
+# due to https://github.com/google/textfsm/issues/63
+textfsm = { git = "https://github.com/ktbyers/textfsm.git", branch = "fix_windows_import_pin" }
 
 [tool.poetry.extras]
 # The following section is required to install docs dependencies


### PR DESCRIPTION
I recognize this is development only dependency, but since I am very frequently working on Netmiko (which requires TextFSM) and NAPALM, reverting back to the downrev textfsm 0.4.1 is going to cause me a lot of pain in dependency management.

So I would rather roll forward and include the windows patch here.

That branch I included won't change.