### PR TITLE
Set napalm connection options if they exist in netbox

### DIFF
--- a/tests/plugins/inventory/netbox/2.3.5/expected.json
+++ b/tests/plugins/inventory/netbox/2.3.5/expected.json
@@ -5,7 +5,7 @@
 			"hostname": "10.0.1.1",
 			"username": null,
 			"password": null,
-			"platform": null,
+			"platform": "junos",
 			"data": {
 				"serial": "",
 				"vendor": "Juniper",
@@ -22,7 +22,7 @@
 			"hostname": "172.16.2.1",
 			"username": null,
 			"password": null,
-			"platform": null,
+			"platform": "junos",
 			"data": {
 				"serial": "",
 				"vendor": "Juniper",
@@ -57,7 +57,7 @@
 			"hostname": "10.0.1.4",
 			"username": null,
 			"password": null,
-			"platform": null,
+			"platform": "junos",
 			"data": {
 				"serial": "",
 				"vendor": "Juniper",

--- a/tests/plugins/inventory/netbox/2.3.5/expected_use_platform_args.json
+++ b/tests/plugins/inventory/netbox/2.3.5/expected_use_platform_args.json
@@ -12,10 +12,22 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"napalm": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+				}
+			},
 			"groups": []
 		},
 		"2-Distribution": {
@@ -30,10 +42,22 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "ex4550-32f",
-				"platform": "junos"
+				"model": "ex4550-32f"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"napalm": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+				}
+			},
 			"groups": []
 		},
 		"3-Access": {
@@ -49,8 +73,7 @@
 				"asset_tag": null,
 				"site": "san-jose-ca",
 				"role": "sw",
-				"model": "3650-48tq-l",
-				"platform": "ios"
+				"model": "3650-48tq-l"
 			},
 			"connection_options": {},
 			"groups": []
@@ -67,10 +90,22 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"napalm": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+				}
+			},
 			"groups": []
 		}
 	},

--- a/tests/plugins/inventory/netbox/2.3.5/expected_use_platform_args_conn_opts.json
+++ b/tests/plugins/inventory/netbox/2.3.5/expected_use_platform_args_conn_opts.json
@@ -12,10 +12,22 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"junos": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+			    }
+			},
 			"groups": []
 		},
 		"2-Distribution": {
@@ -30,10 +42,22 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "ex4550-32f",
-				"platform": "junos"
+				"model": "ex4550-32f"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"junos": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+			    }
+			},
 			"groups": []
 		},
 		"3-Access": {
@@ -49,8 +73,7 @@
 				"asset_tag": null,
 				"site": "san-jose-ca",
 				"role": "sw",
-				"model": "3650-48tq-l",
-				"platform": "ios"
+				"model": "3650-48tq-l"
 			},
 			"connection_options": {},
 			"groups": []
@@ -67,10 +90,22 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"junos": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+			    }
+			},
 			"groups": []
 		}
 	},

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/devices-0.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/devices-0.json
@@ -26,7 +26,7 @@
         "slug": "rt"
       },
       "tenant": null,
-      "platform": null,
+      "platform": "junos",
       "serial": "",
       "asset_tag": null,
       "site": {

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/devices-1.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/devices-1.json
@@ -26,7 +26,7 @@
         "slug": "rt"
       },
       "tenant": null,
-      "platform": null,
+      "platform": "junos",
       "serial": "",
       "asset_tag": null,
       "site": {

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/devices-2.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/devices-2.json
@@ -88,7 +88,7 @@
         "slug": "rt"
       },
       "tenant": null,
-      "platform": null,
+      "platform": "junos",
       "serial": "",
       "asset_tag": null,
       "site": {

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/devices.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/devices.json
@@ -26,7 +26,7 @@
         "slug": "rt"
       },
       "tenant": null,
-      "platform": null,
+      "platform": "junos",
       "serial": "",
       "asset_tag": null,
       "site": {
@@ -88,7 +88,7 @@
         "slug": "rt"
       },
       "tenant": null,
-      "platform": null,
+      "platform": "junos",
       "serial": "",
       "asset_tag": null,
       "site": {
@@ -212,7 +212,7 @@
         "slug": "rt"
       },
       "tenant": null,
-      "platform": null,
+      "platform": "junos",
       "serial": "",
       "asset_tag": null,
       "site": {

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/platforms.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/platforms.json
@@ -1,0 +1,24 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "name": "junos",
+      "slug": "junos",
+      "manufacturer": {
+        "id": 1,
+        "url": "http://localhost:8080/api/dcim/manufacturers/1/",
+        "name": "juniper",
+        "slug": "juniper"
+      },
+      "napalm_driver": "junos",
+      "napalm_args": {
+        "ignore_warning": true
+      },
+      "device_count": 2,
+      "virtualmachine_count": null
+    }
+  ]
+}

--- a/tests/plugins/inventory/netbox/2.3.5/mocked/platforms_conn_opts.json
+++ b/tests/plugins/inventory/netbox/2.3.5/mocked/platforms_conn_opts.json
@@ -1,0 +1,30 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "name": "junos",
+      "slug": "junos",
+      "manufacturer": {
+        "id": 1,
+        "url": "http://localhost:8080/api/dcim/manufacturers/1/",
+        "name": "juniper",
+        "slug": "juniper"
+      },
+      "napalm_driver": "junos",
+      "napalm_args": {
+        "junos": {
+          "extras": {
+            "optional_args": {
+              "ignore_warning": true
+            }
+          }
+        }
+      },
+      "device_count": 2,
+      "virtualmachine_count": null
+    }
+  ]
+}

--- a/tests/plugins/inventory/netbox/2.8.9/expected.json
+++ b/tests/plugins/inventory/netbox/2.8.9/expected.json
@@ -12,8 +12,7 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
 			"connection_options": {},
 			"groups": []
@@ -30,8 +29,7 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "ex4550-32f",
-				"platform": "junos"
+				"model": "ex4550-32f"
 			},
 			"connection_options": {},
 			"groups": []
@@ -43,18 +41,16 @@
 			"password": null,
 			"platform": null,
 			"data": {
-                "user_defined": 1,
 				"serial": "",
 				"vendor": "Cisco",
 				"asset_tag": null,
 				"site": "san-jose-ca",
 				"role": "sw",
-				"model": "3650-48tq-l",
-				"platform": "ios"
+				"model": "3650-48tq-l"
 			},
 			"connection_options": {},
 			"groups": []
-		},
+	  },
 		"4": {
 			"port": null,
 			"hostname": "10.0.1.4",
@@ -67,8 +63,7 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
 			"connection_options": {},
 			"groups": []

--- a/tests/plugins/inventory/netbox/2.8.9/expected_transform_function.json
+++ b/tests/plugins/inventory/netbox/2.8.9/expected_transform_function.json
@@ -43,7 +43,6 @@
 			"password": null,
 			"platform": null,
 			"data": {
-                "user_defined": 1,
 				"serial": "",
 				"vendor": "Cisco",
 				"asset_tag": null,

--- a/tests/plugins/inventory/netbox/2.8.9/expected_use_platform_args.json
+++ b/tests/plugins/inventory/netbox/2.8.9/expected_use_platform_args.json
@@ -12,10 +12,22 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"napalm": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+				}
+			},
 			"groups": []
 		},
 		"2-Distribution": {
@@ -30,10 +42,22 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "ex4550-32f",
-				"platform": "junos"
+				"model": "ex4550-32f"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"napalm": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+				}
+			},
 			"groups": []
 		},
 		"3-Access": {
@@ -43,14 +67,12 @@
 			"password": null,
 			"platform": null,
 			"data": {
-                "user_defined": 1,
 				"serial": "",
 				"vendor": "Cisco",
 				"asset_tag": null,
 				"site": "san-jose-ca",
 				"role": "sw",
-				"model": "3650-48tq-l",
-				"platform": "ios"
+				"model": "3650-48tq-l"
 			},
 			"connection_options": {},
 			"groups": []
@@ -67,13 +89,25 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"napalm": {
+					"extras": {
+						"optional_args": {
+							"ignore_warning": true
+						}
+					},
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+				}
+			},
 			"groups": []
 		}
-	},
+	},	
 	"groups": {},
 	"defaults": {
 		"port": null,

--- a/tests/plugins/inventory/netbox/2.8.9/expected_use_platform_args_conn_opts.json
+++ b/tests/plugins/inventory/netbox/2.8.9/expected_use_platform_args_conn_opts.json
@@ -12,10 +12,21 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"netmiko": {
+					"extras": {
+            "ssh_config_file": "~/.ssh/config",
+            "use_keys": true
+          },
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+			    }
+			},
 			"groups": []
 		},
 		"2-Distribution": {
@@ -30,10 +41,21 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "ex4550-32f",
-				"platform": "junos"
+				"model": "ex4550-32f"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"netmiko": {
+					"extras": {
+            "ssh_config_file": "~/.ssh/config",
+            "use_keys": true
+          },
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+			  }
+			},
 			"groups": []
 		},
 		"3-Access": {
@@ -43,14 +65,12 @@
 			"password": null,
 			"platform": null,
 			"data": {
-                "user_defined": 1,
 				"serial": "",
 				"vendor": "Cisco",
 				"asset_tag": null,
 				"site": "san-jose-ca",
 				"role": "sw",
-				"model": "3650-48tq-l",
-				"platform": "ios"
+				"model": "3650-48tq-l"
 			},
 			"connection_options": {},
 			"groups": []
@@ -67,10 +87,21 @@
 				"asset_tag": null,
 				"site": "sunnyvale-ca",
 				"role": "rt",
-				"model": "mx480",
-				"platform": "junos"
+				"model": "mx480"
 			},
-			"connection_options": {},
+			"connection_options": {
+				"netmiko": {
+					"extras": {
+            "ssh_config_file": "~/.ssh/config",
+            "use_keys": true
+          },
+					"hostname": null,
+					"password": null,
+					"platform": null,
+					"port": null,
+					"username": null
+				}
+			},
 			"groups": []
 		}
 	},

--- a/tests/plugins/inventory/netbox/2.8.9/mocked/devices-0.json
+++ b/tests/plugins/inventory/netbox/2.8.9/mocked/devices-0.json
@@ -1,0 +1,79 @@
+{
+    "count": 1,
+    "next": "http://localhost:8080/api/dcim/devices/?limit=0&offset=1",
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "name": "1-Core",
+            "display_name": "1-Core",
+            "device_type": {
+                "id": 11,
+                "url": "http://localhost:8080/api/dcim/device-types/11/",
+                "manufacturer": {
+                    "id": 3,
+                    "url": "http://localhost:8080/api/dcim/manufacturers/3/",
+                    "name": "Juniper",
+                    "slug": "juniper"
+                },
+                "model": "MX480",
+                "slug": "mx480",
+                "display_name": "Juniper MX480"
+            },
+            "device_role": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/device-roles/1/",
+                "name": "Router",
+                "slug": "rt"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/platforms/1/",
+                "name": "junos",
+                "slug": "junos"
+            },
+            "serial": "",
+            "asset_tag": null,
+            "site": {
+                "id": 3,
+                "url": "http://localhost:8080/api/dcim/sites/3/",
+                "name": "Sunnyvale, CA",
+                "slug": "sunnyvale-ca"
+            },
+            "rack": null,
+            "position": null,
+            "face": null,
+            "parent_device": null,
+            "status": {
+                "value": "active",
+                "label": "Active",
+                "id": 1
+            },
+            "primary_ip": {
+                "id": 1,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/1/",
+                "family": 4,
+                "address": "10.0.1.1/32"
+            },
+            "primary_ip4": {
+                "id": 1,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/1/",
+                "family": 4,
+                "address": "10.0.1.1/32"
+            },
+            "primary_ip6": null,
+            "cluster": null,
+            "virtual_chassis": null,
+            "vc_position": null,
+            "vc_priority": null,
+            "comments": "",
+            "local_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-03-29",
+            "last_updated": "2020-07-09T14:27:20.449532Z"
+        }
+    ]
+}

--- a/tests/plugins/inventory/netbox/2.8.9/mocked/devices-1.json
+++ b/tests/plugins/inventory/netbox/2.8.9/mocked/devices-1.json
@@ -1,0 +1,79 @@
+{
+    "count": 1,
+    "next": "http://localhost:8080/api/dcim/devices/?limit=0&offset=2",
+    "previous": "http://localhost:8080/api/dcim/devices/?limit=0&offset=0",
+    "results": [
+        {
+            "id": 2,
+            "name": "2-Distribution",
+            "display_name": "2-Distribution",
+            "device_type": {
+                "id": 9,
+                "url": "http://localhost:8080/api/dcim/device-types/9/",
+                "manufacturer": {
+                    "id": 3,
+                    "url": "http://localhost:8080/api/dcim/manufacturers/3/",
+                    "name": "Juniper",
+                    "slug": "juniper"
+                },
+                "model": "EX4550-32F",
+                "slug": "ex4550-32f",
+                "display_name": "Juniper EX4550-32F"
+            },
+            "device_role": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/device-roles/1/",
+                "name": "Router",
+                "slug": "rt"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/platforms/1/",
+                "name": "junos",
+                "slug": "junos"
+            },
+            "serial": "",
+            "asset_tag": null,
+            "site": {
+                "id": 3,
+                "url": "http://localhost:8080/api/dcim/sites/3/",
+                "name": "Sunnyvale, CA",
+                "slug": "sunnyvale-ca"
+            },
+            "rack": null,
+            "position": null,
+            "face": null,
+            "parent_device": null,
+            "status": {
+                "value": "active",
+                "label": "Active",
+                "id": 1
+            },
+            "primary_ip": {
+                "id": 2,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/2/",
+                "family": 4,
+                "address": "172.16.2.1/32"
+            },
+            "primary_ip4": {
+                "id": 2,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/2/",
+                "family": 4,
+                "address": "172.16.2.1/32"
+            },
+            "primary_ip6": null,
+            "cluster": null,
+            "virtual_chassis": null,
+            "vc_position": null,
+            "vc_priority": null,
+            "comments": "",
+            "local_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-03-29",
+            "last_updated": "2020-07-09T14:27:20.449532Z"
+        }
+    ]
+}

--- a/tests/plugins/inventory/netbox/2.8.9/mocked/devices-2.json
+++ b/tests/plugins/inventory/netbox/2.8.9/mocked/devices-2.json
@@ -1,0 +1,146 @@
+{
+    "count": 2,
+    "next": null,
+    "previous": "http://localhost:8080/api/dcim/devices/?limit=0&offset=1",
+    "results": [
+        {
+            "id": 3,
+            "name": "3-Access",
+            "display_name": "3-Access",
+            "device_type": {
+                "id": 2,
+                "url": "http://localhost:8080/api/dcim/device-types/2/",
+                "manufacturer": {
+                    "id": 2,
+                    "url": "http://localhost:8080/api/dcim/manufacturers/2/",
+                    "name": "Cisco",
+                    "slug": "cisco"
+                },
+                "model": "3650-48TQ-L",
+                "slug": "3650-48tq-l",
+                "display_name": "Cisco 3650-48TQ-L"
+            },
+            "device_role": {
+                "id": 2,
+                "url": "http://localhost:8080/api/dcim/device-roles/2/",
+                "name": "Switch",
+                "slug": "sw"
+            },
+            "tenant": null,
+            "platform": null,
+            "serial": "",
+            "asset_tag": null,
+            "site": {
+                "id": 2,
+                "url": "http://localhost:8080/api/dcim/sites/2/",
+                "name": "San Jose, CA",
+                "slug": "san-jose-ca"
+            },
+            "rack": null,
+            "position": null,
+            "face": null,
+            "parent_device": null,
+            "status": {
+                "value": "active",
+                "label": "Active",
+                "id": 1
+            },
+            "primary_ip": {
+                "id": 3,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/3/",
+                "family": 4,
+                "address": "192.168.3.1/32"
+            },
+            "primary_ip4": {
+                "id": 3,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/3/",
+                "family": 4,
+                "address": "192.168.3.1/32"
+            },
+            "primary_ip6": null,
+            "cluster": null,
+            "virtual_chassis": null,
+            "vc_position": null,
+            "vc_priority": null,
+            "comments": "",
+            "local_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-03-29",
+            "last_updated": "2020-07-09T14:27:20.449532Z"
+        },
+        {
+            "id": 4,
+            "name": null,
+            "display_name": "MX480",
+            "device_type": {
+                "id": 3,
+                "url": "http://localhost:8080/api/dcim/device-types/11/",
+                "manufacturer": {
+                    "id": 2,
+                    "url": "http://localhost:8080/api/dcim/manufacturers/3/",
+                    "name": "Juniper",
+                    "slug": "juniper"
+                },
+                "model": "MX480",
+                "slug": "mx480",
+                "display_name": "Juniper MX480"
+            },
+            "device_role": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/device-roles/1/",
+                "name": "Router",
+                "slug": "rt"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/platforms/1/",
+                "name": "junos",
+                "slug": "junos"
+            },
+            "serial": "",
+            "asset_tag": null,
+            "site": {
+                "id": 3,
+                "url": "http://localhost:8080/api/dcim/sites/3/",
+                "name": "Sunnyvale, CA",
+                "slug": "sunnyvale-ca"
+            },
+            "rack": null,
+            "position": null,
+            "face": null,
+            "parent_device": null,
+            "status": {
+                "value": "active",
+                "label": "Active",
+                "id": 1
+            },
+            "primary_ip": {
+                "id": 4,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/4/",
+                "family": 4,
+                "address": "10.0.1.4/32"
+            },
+            "primary_ip4": {
+                "id": 4,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/4/",
+                "family": 4,
+                "address": "10.0.1.4/32"
+            },
+            "primary_ip6": null,
+            "cluster": null,
+            "virtual_chassis": null,
+            "vc_position": null,
+            "vc_priority": null,
+            "comments": "",
+            "local_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-03-29",
+            "last_updated": "2020-07-09T14:27:20.449532Z"
+        }
+    ]
+}

--- a/tests/plugins/inventory/netbox/2.8.9/mocked/devices.json
+++ b/tests/plugins/inventory/netbox/2.8.9/mocked/devices.json
@@ -1,0 +1,290 @@
+{
+    "count": 4,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "name": "1-Core",
+            "display_name": "1-Core",
+            "device_type": {
+                "id": 11,
+                "url": "http://localhost:8080/api/dcim/device-types/11/",
+                "manufacturer": {
+                    "id": 3,
+                    "url": "http://localhost:8080/api/dcim/manufacturers/3/",
+                    "name": "Juniper",
+                    "slug": "juniper"
+                },
+                "model": "MX480",
+                "slug": "mx480",
+                "display_name": "Juniper MX480"
+            },
+            "device_role": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/device-roles/1/",
+                "name": "Router",
+                "slug": "rt"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/platforms/1/",
+                "name": "junos",
+                "slug": "junos"
+            },
+            "serial": "",
+            "asset_tag": null,
+            "site": {
+                "id": 3,
+                "url": "http://localhost:8080/api/dcim/sites/3/",
+                "name": "Sunnyvale, CA",
+                "slug": "sunnyvale-ca"
+            },
+            "rack": null,
+            "position": null,
+            "face": null,
+            "parent_device": null,
+            "status": {
+                "value": "active",
+                "label": "Active",
+                "id": 1
+            },
+            "primary_ip": {
+                "id": 1,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/1/",
+                "family": 4,
+                "address": "10.0.1.1/32"
+            },
+            "primary_ip4": {
+                "id": 1,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/1/",
+                "family": 4,
+                "address": "10.0.1.1/32"
+            },
+            "primary_ip6": null,
+            "cluster": null,
+            "virtual_chassis": null,
+            "vc_position": null,
+            "vc_priority": null,
+            "comments": "",
+            "local_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-03-29",
+            "last_updated": "2020-07-09T14:27:20.449532Z"
+        },
+        {
+            "id": 2,
+            "name": "2-Distribution",
+            "display_name": "2-Distribution",
+            "device_type": {
+                "id": 9,
+                "url": "http://localhost:8080/api/dcim/device-types/9/",
+                "manufacturer": {
+                    "id": 3,
+                    "url": "http://localhost:8080/api/dcim/manufacturers/3/",
+                    "name": "Juniper",
+                    "slug": "juniper"
+                },
+                "model": "EX4550-32F",
+                "slug": "ex4550-32f",
+                "display_name": "Juniper EX4550-32F"
+            },
+            "device_role": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/device-roles/1/",
+                "name": "Router",
+                "slug": "rt"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/platforms/1/",
+                "name": "junos",
+                "slug": "junos"
+            },
+            "serial": "",
+            "asset_tag": null,
+            "site": {
+                "id": 3,
+                "url": "http://localhost:8080/api/dcim/sites/3/",
+                "name": "Sunnyvale, CA",
+                "slug": "sunnyvale-ca"
+            },
+            "rack": null,
+            "position": null,
+            "face": null,
+            "parent_device": null,
+            "status": {
+                "value": "active",
+                "label": "Active",
+                "id": 1
+            },
+            "primary_ip": {
+                "id": 2,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/2/",
+                "family": 4,
+                "address": "172.16.2.1/32"
+            },
+            "primary_ip4": {
+                "id": 2,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/2/",
+                "family": 4,
+                "address": "172.16.2.1/32"
+            },
+            "primary_ip6": null,
+            "cluster": null,
+            "virtual_chassis": null,
+            "vc_position": null,
+            "vc_priority": null,
+            "comments": "",
+            "local_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-03-29",
+            "last_updated": "2020-07-09T14:27:20.449532Z"
+        },
+        {
+            "id": 3,
+            "name": "3-Access",
+            "display_name": "3-Access",
+            "device_type": {
+                "id": 2,
+                "url": "http://localhost:8080/api/dcim/device-types/2/",
+                "manufacturer": {
+                    "id": 2,
+                    "url": "http://localhost:8080/api/dcim/manufacturers/2/",
+                    "name": "Cisco",
+                    "slug": "cisco"
+                },
+                "model": "3650-48TQ-L",
+                "slug": "3650-48tq-l",
+                "display_name": "Cisco 3650-48TQ-L"
+            },
+            "device_role": {
+                "id": 2,
+                "url": "http://localhost:8080/api/dcim/device-roles/2/",
+                "name": "Switch",
+                "slug": "sw"
+            },
+            "tenant": null,
+            "platform": null,
+            "serial": "",
+            "asset_tag": null,
+            "site": {
+                "id": 2,
+                "url": "http://localhost:8080/api/dcim/sites/2/",
+                "name": "San Jose, CA",
+                "slug": "san-jose-ca"
+            },
+            "rack": null,
+            "position": null,
+            "face": null,
+            "parent_device": null,
+            "status": {
+                "value": "active",
+                "label": "Active",
+                "id": 1
+            },
+            "primary_ip": {
+                "id": 3,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/3/",
+                "family": 4,
+                "address": "192.168.3.1/32"
+            },
+            "primary_ip4": {
+                "id": 3,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/3/",
+                "family": 4,
+                "address": "192.168.3.1/32"
+            },
+            "primary_ip6": null,
+            "cluster": null,
+            "virtual_chassis": null,
+            "vc_position": null,
+            "vc_priority": null,
+            "comments": "",
+            "local_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-03-29",
+            "last_updated": "2020-07-09T14:27:20.449532Z"
+        },
+        {
+            "id": 4,
+            "name": null,
+            "display_name": "MX480",
+            "device_type": {
+                "id": 3,
+                "url": "http://localhost:8080/api/dcim/device-types/11/",
+                "manufacturer": {
+                    "id": 2,
+                    "url": "http://localhost:8080/api/dcim/manufacturers/3/",
+                    "name": "Juniper",
+                    "slug": "juniper"
+                },
+                "model": "MX480",
+                "slug": "mx480",
+                "display_name": "Juniper MX480"
+            },
+            "device_role": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/device-roles/1/",
+                "name": "Router",
+                "slug": "rt"
+            },
+            "tenant": null,
+            "platform": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/platforms/1/",
+                "name": "junos",
+                "slug": "junos"
+            },
+            "serial": "",
+            "asset_tag": null,
+            "site": {
+                "id": 3,
+                "url": "http://localhost:8080/api/dcim/sites/3/",
+                "name": "Sunnyvale, CA",
+                "slug": "sunnyvale-ca"
+            },
+            "rack": null,
+            "position": null,
+            "face": null,
+            "parent_device": null,
+            "status": {
+                "value": "active",
+                "label": "Active",
+                "id": 1
+            },
+            "primary_ip": {
+                "id": 4,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/4/",
+                "family": 4,
+                "address": "10.0.1.4/32"
+            },
+            "primary_ip4": {
+                "id": 4,
+                "url": "http://localhost:8080/api/ipam/ip-addresses/4/",
+                "family": 4,
+                "address": "10.0.1.4/32"
+            },
+            "primary_ip6": null,
+            "cluster": null,
+            "virtual_chassis": null,
+            "vc_position": null,
+            "vc_priority": null,
+            "comments": "",
+            "local_context_data": null,
+            "tags": [],
+            "custom_fields": {},
+            "config_context": {},
+            "created": "2020-03-29",
+            "last_updated": "2020-07-09T14:27:20.449532Z"
+        }
+    ]
+}

--- a/tests/plugins/inventory/netbox/2.8.9/mocked/platforms.json
+++ b/tests/plugins/inventory/netbox/2.8.9/mocked/platforms.json
@@ -1,0 +1,25 @@
+{
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "name": "junos",
+            "slug": "junos",
+            "manufacturer": {
+                "id": 1,
+                "url": "http://localhost:8080/api/dcim/manufacturers/1/",
+                "name": "juniper",
+                "slug": "juniper"
+            },
+            "napalm_driver": "junos",
+            "napalm_args": {
+              "ignore_warning": true
+            },
+            "description": "",
+            "device_count": 3,
+            "virtualmachine_count": null
+        }
+    ]
+}

--- a/tests/plugins/inventory/netbox/2.8.9/mocked/platforms_conn_opts.json
+++ b/tests/plugins/inventory/netbox/2.8.9/mocked/platforms_conn_opts.json
@@ -1,0 +1,29 @@
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "name": "junos",
+      "slug": "junos",
+      "manufacturer": {
+        "id": 1,
+        "url": "http://localhost:8080/api/dcim/manufacturers/1/",
+        "name": "juniper",
+        "slug": "juniper"
+      },
+      "napalm_driver": "junos",
+      "napalm_args": {
+        "netmiko": {
+          "extras": {
+            "ssh_config_file": "~/.ssh/config",
+            "use_keys": true
+          }
+        }
+      },
+      "device_count": 3,
+      "virtualmachine_count": null
+    }
+  ]
+}


### PR DESCRIPTION
It would be beneficial to load napalm optional arguments as connection options based the platform a host is associated with within netbox.

I have a test group called ros (mikrotik) as follows:

![image](https://user-images.githubusercontent.com/5504449/87114019-8c3fb380-c23d-11ea-8b7d-2e2d300b58cb.png)

With this change we can do something like the following to automatically load these into `host['connection_options']['napalm']` based on the device platform:

```
>>> from pprint import pprint
>>> from nornir import InitNornir
>>>
>>> nr = InitNornir(
...     inventory={
...         "plugin": "nornir.plugins.inventory.netbox.NBInventory",
...             "options": {
...                 "nb_url": "https://localhost:8080",
...                 "nb_token": "0123456789abcdef0123456789abcdef01234567",
...                 "ssl_verify": True,
...                 "filter_parameters": {"role": "router", "status": "active"},
...             },
...     },
...     core={"num_workers": 20, "raise_on_error": False},
...     logging={"enabled": False, "level": "error"},
... )
>>>
>>> test_device = nr.filter(name="MA-SAV-CHA-RTR-01")
>>> pprint(test_device.inventory.get_inventory_dict())
{'defaults': {'connection_options': {},
              'data': {},
              'hostname': None,
              'password': None,
              'platform': None,
              'port': None,
              'username': None},
 'groups': {},
 'hosts': {'MA-SAV-CHA-RTR-01': {'connection_options': {'napalm': {'extras': {'optional_args': {'login_methods': ['login_plain']},
                                                                              'timeout': 10},
                                                                   'hostname': None,
                                                                   'password': None,
                                                                   'platform': None,
                                                                   'port': None,
                                                                   'username': None}},
                                 'data': {'asset_tag': None,
                                          'model': 'ccr1036-8g-2s',
                                          'role': 'router',
                                          'serial': 'A7FB0A06CBF7',
                                          'site': '1000_ma-sav-cha',
                                          'vendor': 'Mikrotik'},
                                 'groups': [],
                                 'hostname': '10.10.0.1',
                                 'password': None,
                                 'platform': 'ros',
                                 'port': None,
                                 'username': None}}}
```