### PR TITLE
AnsibleInventory plugins support variables in a subdirectory.

### DIFF
--- a/tests/plugins/inventory/ansible/yaml4/expected/defaults.yaml
+++ b/tests/plugins/inventory/ansible/yaml4/expected/defaults.yaml
@@ -1,0 +1,8 @@
+connection_options: {}
+data:
+  simulate_all_data: simulate_all_data
+hostname: null
+password: null
+platform: null
+port: null
+username: null

--- a/tests/plugins/inventory/ansible/yaml4/expected/groups.yaml
+++ b/tests/plugins/inventory/ansible/yaml4/expected/groups.yaml
@@ -1,0 +1,30 @@
+eric_eccli:
+  connection_options: {}
+  data:
+    ntp_mode:
+      servers:
+        - server_choice: 1.1.1.1
+          version: 3
+          source: management
+        - server_choice: 2.2.2.2
+          version: 3
+          source: management
+        - server_choice: 3.3.3.3
+          version: 3
+          source: management
+  groups: []
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null
+frontend:
+  connection_options: {}
+  data:
+    simulate_iosxr_data: simulate_iosxr_data 
+  groups: []
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null

--- a/tests/plugins/inventory/ansible/yaml4/expected/hosts.yaml
+++ b/tests/plugins/inventory/ansible/yaml4/expected/hosts.yaml
@@ -1,0 +1,26 @@
+lab_a_router_02:
+  connection_options: {}
+  data:
+    interfaces:
+      loopback1:
+        ip: 1.2.3.4/32
+  groups:
+  - eric_eccli
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null
+lab_a_router_01:
+  connection_options: {}
+  data:
+    interfaces:
+      loopback1:
+        ip: 4.3.2.1/32
+  groups:
+    - iosxr
+  hostname: null
+  password: null
+  platform: null
+  port: null
+  username: null

--- a/tests/plugins/inventory/ansible/yaml4/source/group_vars/all/vars.yml
+++ b/tests/plugins/inventory/ansible/yaml4/source/group_vars/all/vars.yml
@@ -1,0 +1,2 @@
+---
+simulate_all_data: simulate_all_data

--- a/tests/plugins/inventory/ansible/yaml4/source/group_vars/eric_eccli/ntp/ntp.yml
+++ b/tests/plugins/inventory/ansible/yaml4/source/group_vars/eric_eccli/ntp/ntp.yml
@@ -1,0 +1,12 @@
+---
+ntp_mode:
+  servers:
+    - server_choice: 1.1.1.1
+      version: 3
+      source: management
+    - server_choice: 2.2.2.2
+      version: 3
+      source: management
+    - server_choice: 3.3.3.3
+      version: 3
+      source: management

--- a/tests/plugins/inventory/ansible/yaml4/source/group_vars/iosxr.yml
+++ b/tests/plugins/inventory/ansible/yaml4/source/group_vars/iosxr.yml
@@ -1,0 +1,2 @@
+---
+simulate_iosxr_data: simulate_iosxr_data 

--- a/tests/plugins/inventory/ansible/yaml4/source/host_vars/lab_a_router_01.yml
+++ b/tests/plugins/inventory/ansible/yaml4/source/host_vars/lab_a_router_01.yml
@@ -1,0 +1,4 @@
+---
+interfaces:
+  loopback1:
+    ip: 4.3.2.1/32

--- a/tests/plugins/inventory/ansible/yaml4/source/host_vars/lab_a_router_02/vars.yml
+++ b/tests/plugins/inventory/ansible/yaml4/source/host_vars/lab_a_router_02/vars.yml
@@ -1,0 +1,4 @@
+---
+interfaces:
+  loopback1:
+    ip: 1.2.3.4/32

--- a/tests/plugins/inventory/ansible/yaml4/source/inventory.yml
+++ b/tests/plugins/inventory/ansible/yaml4/source/inventory.yml
@@ -1,0 +1,12 @@
+all:
+  children:
+    lab_hosts:
+      hosts:
+        lab_a_router_01: {}
+        lab_a_router_02: {}
+    iosxr:
+      hosts:
+        lab_a_router_01: {}
+    eric_eccli:
+      hosts:
+        lab_a_router_02: {}


### PR DESCRIPTION
As example:
```
inventories/lab//host_vars
├── lab_a_router_01
│   ├── interfaces.yml
│   ├── vars.yml
│   └── vault.yml
└── lab_a_router_02
    ├── s_links.yml
    ├── s_vars.yml
    ├── vars.yml
    ├── y_bfd.yml
    ├── y_interfaces.
```

> Probably an improvement is necessary for code quality!