### PR TITLE
fixes issue with urlencoding for filenames/repository in gitlab

### DIFF
--- a/docs/plugins/tasks/version_control/gitlab.ipynb
+++ b/docs/plugins/tasks/version_control/gitlab.ipynb
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -157,10 +157,9 @@
     "        with requests_mock.Mocker() as m:\n",
     "            if kwargs.get(\"ref\", None):\n",
     "                kwargs[\"branch\"] = kwargs[\"ref\"]\n",
-    "            m.get(url=f\"{kwargs['url']}/api/v4/projects?search={kwargs['repository']}\", status_code=200, json=[{\"name\":\"test\",\"id\":1}])\n",
-    "            m.post(url=f\"{kwargs['url']}/api/v4/projects/1/repository/files/{kwargs['filename']}\", status_code=201)\n",
-    "            m.get(url=f\"{kwargs['url']}/api/v4/projects/1/repository/files/{kwargs['filename']}?ref={kwargs['branch']}\",status_code=200, json={\"content\":\"MTI3LjAuMC4xCQlsb2NhbGhvc3QKMjU1LjI1NS4yNTUuMjU1CWJyb2FkY2FzdGhvc3QKOjoxCQls\\nb2NhbGhvc3QK\\n\"})\n",
-    "            m.put(url=f\"{kwargs['url']}/api/v4/projects/1/repository/files/{kwargs['filename']}\", status_code=200)\n",
+    "            m.post(url=f\"{kwargs['url']}/api/v4/projects/{kwargs['repository']}/repository/files/{kwargs['filename']}\", status_code=201)\n",
+    "            m.get(url=f\"{kwargs['url']}/api/v4/projects/{kwargs['repository']}/repository/files/{kwargs['filename']}?ref={kwargs['branch']}\",status_code=200, json={\"content\":\"MTI3LjAuMC4xCQlsb2NhbGhvc3QKMjU1LjI1NS4yNTUuMjU1CWJyb2FkY2FzdGhvc3QKOjoxCQls\\nb2NhbGhvc3QK\\n\"})\n",
+    "            m.put(url=f\"{kwargs['url']}/api/v4/projects/{kwargs['repository']}/repository/files/{kwargs['filename']}\", status_code=200)\n",
     "            return f(*args, **kwargs)\n",
     "    return wrapper\n",
     "\n",
@@ -169,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -208,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -269,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -307,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -372,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -418,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "autoscroll": false,
     "ein.hycell": false,
@@ -484,7 +483,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.6"
   },
   "name": "gitlab.ipynb"
  },

--- a/nornir/plugins/tasks/version_control/gitlab.py
+++ b/nornir/plugins/tasks/version_control/gitlab.py
@@ -199,8 +199,6 @@ def gitlab(
     if commit_message == "":
         commit_message = "File created with nornir"
 
-    # pid = _get_repository(session, url, repository)
-
     if action == "create":
         diff = _create(
             task,

--- a/tests/plugins/tasks/version_control/test_gitlab.py
+++ b/tests/plugins/tasks/version_control/test_gitlab.py
@@ -87,10 +87,10 @@ def update_file(
     resp,
 ):
     token = "dummy"
-
     quoted_repository = quote(repository, safe="")
     exists_file_url = (
-        f"{url}/api/v4/projects/{quoted_repository}/repository/files/{filename}?ref={branch}"
+        f"{url}/api/v4/projects/{quoted_repository}/repository/files/{filename}"
+        f"?ref={branch}"
     )
     requests_mock.get(exists_file_url, status_code=exists_status_code, json=exists_resp)
 
@@ -127,12 +127,11 @@ def get_file(
     ref,
 ):
     token = "dummy"
-
     quoted_repository = quote(repository, safe="")
     exists_file_url = (
-        f"{url}/api/v4/projects/{quoted_repository}/repository/files/{filename}?ref={ref}"
+        f"{url}/api/v4/projects/{quoted_repository}/repository/files/{filename}"
+        f"?ref={ref}"
     )
-
     requests_mock.get(exists_file_url, status_code=exists_status_code, json=exists_resp)
 
     res = nornir.run(

--- a/tests/plugins/tasks/version_control/test_gitlab.py
+++ b/tests/plugins/tasks/version_control/test_gitlab.py
@@ -1,5 +1,7 @@
-import os
 import uuid
+import os
+
+from urllib.parse import quote
 
 from nornir.plugins.tasks.version_control import gitlab
 
@@ -37,7 +39,6 @@ def create_file(
     requests_mock,
     url,
     repository,
-    pid,
     branch,
     filename,
     content,
@@ -45,16 +46,14 @@ def create_file(
     dry_run,
     commit_message,
     status_code,
-    project_status_code,
-    project_resp,
     resp,
 ):
     token = "dummy"
 
-    repo_url = f"{url}/api/v4/projects?search={repository}"
-    requests_mock.get(repo_url, status_code=project_status_code, json=project_resp)
-
-    create_file_url = f"{url}/api/v4/projects/{pid}/repository/files/{filename}"
+    quoted_repository = quote(repository, safe="")
+    create_file_url = (
+        f"{url}/api/v4/projects/{quoted_repository}/repository/files/{filename}"
+    )
     requests_mock.post(create_file_url, status_code=status_code, json=resp)
 
     res = nornir.run(
@@ -77,30 +76,27 @@ def update_file(
     requests_mock,
     url,
     repository,
-    pid,
     branch,
     filename,
     content,
     dry_run,
     commit_message,
     status_code,
-    project_status_code,
     exists_status_code,
-    project_resp,
     exists_resp,
     resp,
 ):
     token = "dummy"
 
-    repo_url = f"{url}/api/v4/projects?search={repository}"
-    requests_mock.get(repo_url, status_code=project_status_code, json=project_resp)
-
+    quoted_repository = quote(repository, safe="")
     exists_file_url = (
-        f"{url}/api/v4/projects/{pid}/repository/files/{filename}?ref={branch}"
+        f"{url}/api/v4/projects/{quoted_repository}/repository/files/{filename}?ref={branch}"
     )
     requests_mock.get(exists_file_url, status_code=exists_status_code, json=exists_resp)
 
-    update_file_url = f"{url}/api/v4/projects/{pid}/repository/files/{filename}"
+    update_file_url = (
+        f"{url}/api/v4/projects/{quoted_repository}/repository/files/{filename}"
+    )
     requests_mock.put(update_file_url, status_code=status_code, json=resp)
 
     res = nornir.run(
@@ -123,23 +119,18 @@ def get_file(
     requests_mock,
     url,
     repository,
-    pid,
     filename,
     destination,
     dry_run,
-    project_status_code,
     exists_status_code,
-    project_resp,
     exists_resp,
     ref,
 ):
     token = "dummy"
 
-    repo_url = f"{url}/api/v4/projects?search={repository}"
-    requests_mock.get(repo_url, status_code=project_status_code, json=project_resp)
-
+    quoted_repository = quote(repository, safe="")
     exists_file_url = (
-        f"{url}/api/v4/projects/{pid}/repository/files/{filename}?ref={ref}"
+        f"{url}/api/v4/projects/{quoted_repository}/repository/files/{filename}?ref={ref}"
     )
 
     requests_mock.get(exists_file_url, status_code=exists_status_code, json=exists_resp)
@@ -166,7 +157,6 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             branch="master",
             filename="dummy",
             content="dummy",
@@ -174,8 +164,6 @@ class Test(object):
             dry_run=True,
             commit_message="commit",
             status_code=201,
-            project_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
             resp={"branch": "master", "file_path": "dummy"},
         )
 
@@ -190,7 +178,6 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             branch="master",
             filename="dummy",
             content="dummy",
@@ -198,8 +185,6 @@ class Test(object):
             dry_run=False,
             commit_message="commit",
             status_code=201,
-            project_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
             resp={"branch": "master", "file_path": "dummy"},
         )
 
@@ -214,7 +199,6 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             branch="master",
             filename="dummy",
             content="dummy",
@@ -222,31 +206,6 @@ class Test(object):
             dry_run=False,
             commit_message="commit",
             status_code=400,
-            project_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
-            resp={"branch": "master", "file_path": "dummy"},
-        )
-
-        assert res["dev1.group_1"][0].failed
-        assert not res["dev1.group_1"][0].changed
-
-    def test_gitlab_create_invalid_project(self, nornir, requests_mock):
-        nornir = nornir.filter(name="dev1.group_1")
-        res = create_file(
-            nornir=nornir,
-            requests_mock=requests_mock,
-            url="http://localhost",
-            repository="test",
-            pid=1,
-            branch="master",
-            filename="dummy",
-            content="dummy",
-            action="create",
-            dry_run=False,
-            commit_message="commit",
-            status_code=201,
-            project_status_code=200,
-            project_resp=[{"name": "aaa", "id": 1}],
             resp={"branch": "master", "file_path": "dummy"},
         )
 
@@ -260,7 +219,6 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             branch="bar",
             filename="dummy",
             content="dummy",
@@ -268,8 +226,6 @@ class Test(object):
             dry_run=False,
             commit_message="commit",
             status_code=400,
-            project_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
             resp={"branch": "master", "file_path": "dummy"},
         )
 
@@ -283,16 +239,13 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             branch="master",
             filename="dummy",
             content="new line",
             dry_run=True,
             commit_message="commit",
             status_code=200,
-            project_status_code=200,
             exists_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
             exists_resp={"content": "ZHVtbXk=\n"},
             resp={"branch": "master", "file_path": "dummy"},
         )
@@ -308,45 +261,19 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             branch="master",
             filename="dummy",
             content="new line",
             dry_run=False,
             commit_message="commit",
             status_code=200,
-            project_status_code=200,
             exists_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
             exists_resp={"content": "ZHVtbXk=\n"},
             resp={"branch": "master", "file_path": "dummy"},
         )
         assert not res["dev1.group_1"][0].failed
         assert res["dev1.group_1"][0].changed
         assert res["dev1.group_1"][0].diff == diff_update
-
-    def test_gitlab_update_invalid_project(self, nornir, requests_mock):
-        nornir = nornir.filter(name="dev1.group_1")
-        res = update_file(
-            nornir=nornir,
-            requests_mock=requests_mock,
-            url="http://localhost",
-            repository="test",
-            pid=1,
-            branch="master",
-            filename="dummy",
-            content="new line",
-            dry_run=False,
-            commit_message="commit",
-            status_code=200,
-            project_status_code=200,
-            exists_status_code=200,
-            project_resp=[{"name": "123", "id": 1}],
-            exists_resp={"content": "ZHVtbXk=\n"},
-            resp={"branch": "master", "file_path": "dummy"},
-        )
-        assert res["dev1.group_1"][0].failed
-        assert not res["dev1.group_1"][0].changed
 
     def test_gitlab_update_invalid_branch(self, nornir, requests_mock):
         nornir = nornir.filter(name="dev1.group_1")
@@ -355,16 +282,13 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             branch="bar",
             filename="dummy",
             content="new line",
             dry_run=False,
             commit_message="commit",
             status_code=200,
-            project_status_code=200,
             exists_status_code=400,
-            project_resp=[{"name": "test", "id": 1}],
             exists_resp="",
             resp={"branch": "master", "file_path": "dummy"},
         )
@@ -378,16 +302,13 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             branch="master",
             filename="bar",
             content="new line",
             dry_run=False,
             commit_message="commit",
             status_code=200,
-            project_status_code=200,
             exists_status_code=400,
-            project_resp=[{"name": "test", "id": 1}],
             exists_resp={"content": "ZHVtbXk=\n"},
             resp={"branch": "master", "file_path": "dummy"},
         )
@@ -402,13 +323,10 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             filename="bar",
             dry_run=True,
             destination=f"/tmp/{u}",
-            project_status_code=200,
             exists_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
             exists_resp={"content": "Y29udGVudA==\n"},
             ref="master",
         )
@@ -426,13 +344,10 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             filename="bar",
             dry_run=False,
             destination=f"/tmp/{u}",
-            project_status_code=200,
             exists_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
             exists_resp={"content": "Y29udGVudA==\n"},
             ref="master",
         )
@@ -442,27 +357,6 @@ class Test(object):
         assert res["dev1.group_1"][0].changed
         assert res["dev1.group_1"][0].diff == diff
 
-    def test_gitlab_get_invalid_project(self, nornir, requests_mock):
-        nornir = nornir.filter(name="dev1.group_1")
-        res = get_file(
-            nornir=nornir,
-            requests_mock=requests_mock,
-            url="http://localhost",
-            repository="test",
-            pid=2,
-            filename="bar",
-            dry_run=False,
-            destination="/tmp/foo",
-            project_status_code=400,
-            exists_status_code=200,
-            project_resp=[{"name": "test", "id": 1}],
-            exists_resp={"content": "Y29udGVudA==\n"},
-            ref="master",
-        )
-
-        assert res["dev1.group_1"][0].failed
-        assert not res["dev1.group_1"][0].changed
-
     def test_gitlab_get_invalid_branch(self, nornir, requests_mock):
         nornir = nornir.filter(name="dev1.group_1")
         res = get_file(
@@ -470,13 +364,10 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             filename="bar",
             dry_run=False,
             destination="/tmp/foo",
-            project_status_code=200,
             exists_status_code=400,
-            project_resp=[{"name": "test", "id": 1}],
             exists_resp={"content": "Y29udGVudA==\n"},
             ref="lll",
         )
@@ -491,13 +382,10 @@ class Test(object):
             requests_mock=requests_mock,
             url="http://localhost",
             repository="test",
-            pid=1,
             filename="baz",
             dry_run=False,
             destination="/tmp/foo",
-            project_status_code=200,
             exists_status_code=400,
-            project_resp=[{"name": "test", "id": 1}],
             exists_resp={"content": "Y29udGVudA==\n"},
             ref="",
         )


### PR DESCRIPTION
Fixes an issue with filenames (paths) & namespaced repositories, that contain characters which should be urlencoded.
This PR is basically the same as #455, but it solves some concerns that didn't receive updates.

Fixes #454