### PR TITLE
added grammar parser for F object

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,6 +84,7 @@ jobs:
 
       - name: Run nbval
         run: make nbval
+        if: ${{ matrix.platform != 'windows-latest' }}
 
   release:
     name: Releasing to pypi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-python@v1
 
       - name: install libxml2
-        run: apt-get install libxml2-dev libxslt-dev
+        run: sudo apt-get install libxml2-dev libxslt-dev
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,6 +61,7 @@ jobs:
 
       - name: install libxml2
         run: sudo apt-get install libxml2-dev libxslt-dev
+        if: ${{ matrix.platform == 'ubuntu-latest' }}
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.2
@@ -86,7 +87,6 @@ jobs:
 
       - name: Run nbval
         run: make nbval
-        if: ${{ matrix.platform != 'windows-latest' }}
 
   release:
     name: Releasing to pypi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,7 @@ jobs:
           architecture: x64
 
       - name: install libxml2
-        run: apt-get install libxml2-dev libxslt-dev
+        run: sudo apt-get install libxml2-dev libxslt-dev
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,9 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v1
 
+      - name: install libxml2
+        run: apt-get install libxml2-dev libxslt-dev
+
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.2
 
@@ -55,6 +58,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+
+      - name: install libxml2
+        run: apt-get install libxml2-dev libxslt-dev
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,9 +11,6 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v1
 
-      - name: install libxml2
-        run: sudo apt-get install libxml2-dev libxslt-dev
-
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.2
         with:
@@ -60,10 +57,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-
-      - name: install libxml2
-        run: sudo apt-get install libxml2-dev libxslt-dev
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.2

--- a/nornir/core/filter.py
+++ b/nornir/core/filter.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Protocol
+from typing import Any, List
+from typing_extensions import Protocol
 
 from nornir.core.inventory import Host
 

--- a/nornir/core/filter_parser.py
+++ b/nornir/core/filter_parser.py
@@ -1,0 +1,155 @@
+from ast import literal_eval
+import shlex
+from typing import Any, List, Optional
+
+from nornir.core.filter import AND, OR, F, F_FILTER, NOT
+
+
+EmptyExpression = SyntaxError("got empty expression")
+
+_NOT = "NOT"
+
+_EQUAL = "=="
+_NOT_EQUAL = "!="
+
+_AND = "AND"
+_OR = "OR"
+
+_LP = "("
+_RP = ")"
+_LB = "["
+_RB = "]"
+_COMMA = ","
+
+_EOF = ""
+
+_P_P = 5
+_P_NOT = 4
+_P_AND = 3
+_P_OR = 2
+
+
+def _parse_list(sh: shlex.shlex) -> List[Any]:
+    r: List[Any] = []
+    while True:
+        cur = sh.get_token()
+        if cur == _EOF:
+            raise SyntaxError("expected ']', got EOF")
+        elif cur == _RB:
+            break
+        elif cur == _COMMA:
+            continue
+        else:
+            r.append(literal_eval(cur))
+    return r
+
+
+def _parse_op(sh: shlex.shlex) -> F_FILTER:
+    left = sh.get_token()
+
+    op = sh.get_token()
+    if op in ["=", "!"]:
+        op += sh.get_token()
+
+    cur = sh.get_token()
+    if cur == _LB:
+        right = _parse_list(sh)
+    else:
+        right = literal_eval(cur)
+
+    if op == _EQUAL:
+        return F(**{left: right})
+    elif op == _NOT_EQUAL:
+        return NOT(F(**{left: right}))
+    else:
+        return F(**{f"{left}__{op}": right})
+
+
+def _parse_parenthesis(sh: shlex.shlex) -> F_FILTER:
+    cur = sh.get_token()
+    if cur in ["", ")"]:
+        raise SyntaxError("expresession inside paranthesis is empty")
+
+    sh.push_token(cur)
+
+    f = _parse(sh, _P_P)
+    if f is None:
+        raise ValueError("parenthesis expression didn't yield any filter'")
+
+    cur = sh.get_token()
+    if cur != _RP:
+        raise SyntaxError(f"expected ')', got '{cur}'")
+    return f
+
+
+def _parse_single_expression(sh: shlex.shlex, priority: int) -> Optional[F_FILTER]:
+    cur = sh.get_token()
+
+    if cur in [_EOF, _RP]:
+        sh.push_token(cur)
+        return None
+    elif cur == _NOT:
+        e = _parse_single_expression(sh, _P_NOT)
+        if e is None:
+            raise EmptyExpression
+        f: F_FILTER = NOT(e)
+    elif cur == _LP:
+        f = _parse_parenthesis(sh)
+    else:
+        sh.push_token(cur)
+        f = _parse_op(sh)
+    return f
+
+
+def _parse(sh: shlex.shlex, priority: int) -> Optional[F_FILTER]:
+    f = _parse_single_expression(sh, priority)
+    if f is None:
+        return None
+
+    cur_p = priority
+    while True:
+        cur = sh.get_token()
+
+        if cur in [_EOF, _RP]:
+            sh.push_token(cur)
+            return f
+        elif cur == "AND":
+            left = f
+            right = _parse(sh, _P_AND)
+
+            if right is None:
+                raise EmptyExpression
+
+            if cur_p > _P_AND:
+                f = AND(left, right)
+            else:
+                f = AND(right, left)
+        elif cur == "OR":
+            left = f
+            right = _parse(sh, _P_OR)
+
+            if right is None:
+                raise EmptyExpression
+
+            if cur_p > _P_OR:
+                f = OR(left, right)
+            else:
+                f = OR(right, left)
+        else:
+            raise SyntaxError("you shouldn't be here")
+
+    return f
+
+
+def parse(text: str) -> F_FILTER:
+    sh = shlex.shlex(text)
+    f = _parse(sh, 0)
+    if f is None:
+        if f is None:
+            raise EmptyExpression
+
+    cur = sh.get_token()
+    if cur != _EOF:
+        raise SyntaxError(f"expected EOF, got '{cur}'")
+
+    return f

--- a/tests/core/test_filter_parser.py
+++ b/tests/core/test_filter_parser.py
@@ -1,0 +1,187 @@
+#  from nornir.core.filter import F
+from nornir.core.filter_parser import parse
+
+
+class Test(object):
+    def test_simple(self, nornir):
+        # f = F(site="site1")
+        f = parse("site == 'site1'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1", "dev2.group_1"]
+
+    def test_and(self, nornir):
+        #  f = F(site="site1") & F(role="www")
+        f = parse("site == 'site1' AND role == 'www'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1"]
+
+    def test_or(self, nornir):
+        #  f = F(site="site1") | F(role="www")
+        f = parse("site == 'site1' OR role == 'www'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1", "dev2.group_1", "dev3.group_2"]
+
+    def test_combined(self, nornir):
+        #  f = F(site="site2") | (F(role="www") & F(my_var="comes_from_dev1.group_1"))
+        f = parse(
+            "site == 'site2' OR (role == 'www' AND my_var == 'comes_from_dev1.group_1')"
+        )
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1", "dev3.group_2", "dev4.group_2"]
+
+        #  f = (F(site="site2") | F(role="www")) & F(my_var="comes_from_dev1.group_1")
+        f = parse(
+            "(site == 'site2' OR role == 'www') AND my_var == 'comes_from_dev1.group_1'"
+        )
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1"]
+
+        #  f = F(site="site2") | F(role="www") & F(my_var="comes_from_dev1.group_1")
+        f = parse(
+            "site == 'site2' OR role == 'www' AND my_var == 'comes_from_dev1.group_1'"
+        )
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1", "dev3.group_2", "dev4.group_2"]
+
+    def test_contains(self, nornir):
+        #  f = F(groups__contains="group_1")
+        f = parse("groups contains 'group_1'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1", "dev2.group_1"]
+
+    def test_negate(self, nornir):
+        #  f = ~F(groups__contains="group_1")
+        f = parse("NOT (groups contains 'group_1')")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev3.group_2", "dev4.group_2", "dev5.no_group"]
+
+    def test_negate_and_second_negate(self, nornir):
+        #  f = F(site="site1") & ~F(role="www")
+        f = parse("site == 'site1' AND NOT(role == 'www')")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev2.group_1"]
+
+        f = parse("site == 'site1' AND role != 'www'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev2.group_1"]
+
+    def test_negate_or_both_negate(self, nornir):
+        #  f = ~F(site="site1") | ~F(role="www")
+        f = parse('site != "site1" OR role != "www"')
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == [
+            "dev2.group_1",
+            "dev3.group_2",
+            "dev4.group_2",
+            "dev5.no_group",
+        ]
+
+        f = parse('NOT site == "site1" OR NOT role == "www"')
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == [
+            "dev2.group_1",
+            "dev3.group_2",
+            "dev4.group_2",
+            "dev5.no_group",
+        ]
+
+    def test_nested_data_a_string(self, nornir):
+        #  f = F(nested_data__a_string="asdasd")
+        f = parse("nested_data__a_string == 'asdasd'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1"]
+
+    def test_nested_data_a_string_contains(self, nornir):
+        #  f = F(nested_data__a_string__contains="asd")
+        f = parse("nested_data__a_string__contains == 'asd'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1"]
+
+    def test_nested_data_a_dict_contains(self, nornir):
+        #  f = F(nested_data__a_dict__contains="a")
+        f = parse("nested_data__a_dict__contains=='a'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1"]
+
+    def test_nested_data_a_dict_element(self, nornir):
+        #  f = F(nested_data__a_dict__a=1)
+        f = parse("nested_data__a_dict__a == 1")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1"]
+
+    def test_nested_data_a_dict_doesnt_contain(self, nornir):
+        #  f = ~F(nested_data__a_dict__contains="a")
+        f = parse("NOT nested_data__a_dict__contains=='a'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == [
+            "dev2.group_1",
+            "dev3.group_2",
+            "dev4.group_2",
+            "dev5.no_group",
+        ]
+
+    def test_nested_data_a_list_contains(self, nornir):
+        #  f = F(nested_data__a_list__contains=2)
+        f = parse("nested_data__a_list__contains == 2")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1", "dev2.group_1"]
+
+    def test_filtering_by_callable_has_parent_group(self, nornir):
+        #  f = F(has_parent_group="parent_group")
+        f = parse("has_parent_group == 'parent_group'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1", "dev2.group_1", "dev4.group_2"]
+
+    def test_filtering_by_attribute_name(self, nornir):
+        #  f = F(name="dev1.group_1")
+        f = parse("name=='dev1.group_1'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1"]
+
+    def test_filtering_string_in_list(self, nornir):
+        #  f = F(platform__in=["linux", "mock"])
+        f = parse("platform__in==['linux', 'mock']")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev3.group_2", "dev4.group_2", "dev5.no_group"]
+
+    def test_filtering_list_any(self, nornir):
+        #  f = F(nested_data__a_list__any=[1, 3])
+        f = parse("nested_data__a_list__any==[1, 3]")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1", "dev2.group_1"]
+
+    def test_filtering_list_all(self, nornir):
+        #  f = F(nested_data__a_list__all=[1, 2])
+        f = parse("nested_data__a_list__all==[1, 2]")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == ["dev1.group_1"]
+
+    def test_filter_wrong_attribute_for_type(self, nornir):
+        #  f = F(port__startswith="a")
+        f = parse("port__startswith=='a'")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == []


### PR DESCRIPTION
Implemented a grammar parser that turns a string into an F object. For instance:

* `f = F(site="site1")` is equivalent to `f = parse("site == 'site1'")`
*  `f = (F(site="site2") | F(role="www")) & F(my_var="comes_from_dev1.group_1")` is equivalent to `f = parse("(site == 'site2' OR role == 'www') AND my_var == 'comes_from_dev1.group_1'")`

and long etc.

Look at the tests for more examples.

TODO:
1. Document
2. Get feedback
3. ~Fix CI error which is unrelated to the PR but just your usual python dependency hell~ (thanks to @ktbyers)