### PR TITLE
improvements to data resolution

### DIFF
--- a/docs/tutorial/inventory.ipynb
+++ b/docs/tutorial/inventory.ipynb
@@ -877,7 +877,7 @@
     {
      "data": {
       "text/plain": [
-       "'acme.local'"
+       "'global.local'"
       ]
      },
      "execution_count": 13,

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -263,7 +263,7 @@ class Host(InventoryElement):
 
     def extended_data(self) -> Dict[str, Any]:
         """
-        Returns the data associated with the object included inherited data
+        Returns the data associated with the object including inherited data
         """
         processed = []
         result = {}

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -291,18 +291,25 @@ class Host(InventoryElement):
                 return True
         return False
 
-    def __getitem__(self, item: str) -> Any:
+    def __get(self, item: str) -> Any:
         try:
             return self.data[item]
 
         except KeyError:
             for g in self.groups:
                 try:
-                    r = g[item]
+                    r = g.__get(item)
                     return r
                 except KeyError:
-                    continue
+                    pass
 
+            raise
+
+    def __getitem__(self, item: str) -> Any:
+        try:
+            return self.__get(item)
+
+        except KeyError:
             r = self.defaults.data.get(item)
             if r is not None:
                 return r

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -24,7 +24,12 @@ class Test(object):
         f = F(site="site2") | (F(role="www") & F(my_var="comes_from_dev1.group_1"))
         filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
 
-        assert filtered == ["dev1.group_1", "dev3.group_2", "dev4.group_2"]
+        assert filtered == [
+            "dev1.group_1",
+            "dev3.group_2",
+            "dev4.group_2",
+            "dev6.group_3",
+        ]
 
         f = (F(site="site2") | F(role="www")) & F(my_var="comes_from_dev1.group_1")
         filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
@@ -41,7 +46,12 @@ class Test(object):
         f = ~F(groups__contains="group_1")
         filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
 
-        assert filtered == ["dev3.group_2", "dev4.group_2", "dev5.no_group"]
+        assert filtered == [
+            "dev3.group_2",
+            "dev4.group_2",
+            "dev5.no_group",
+            "dev6.group_3",
+        ]
 
     def test_negate_and_second_negate(self, nornir):
         f = F(site="site1") & ~F(role="www")
@@ -58,6 +68,7 @@ class Test(object):
             "dev3.group_2",
             "dev4.group_2",
             "dev5.no_group",
+            "dev6.group_3",
         ]
 
     def test_nested_data_a_string(self, nornir):
@@ -93,6 +104,7 @@ class Test(object):
             "dev3.group_2",
             "dev4.group_2",
             "dev5.no_group",
+            "dev6.group_3",
         ]
 
     def test_nested_data_a_list_contains(self, nornir):
@@ -105,7 +117,12 @@ class Test(object):
         f = F(has_parent_group="parent_group")
         filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
 
-        assert filtered == ["dev1.group_1", "dev2.group_1", "dev4.group_2"]
+        assert filtered == [
+            "dev1.group_1",
+            "dev2.group_1",
+            "dev4.group_2",
+            "dev6.group_3",
+        ]
 
     def test_filtering_by_attribute_name(self, nornir):
         f = F(name="dev1.group_1")
@@ -117,7 +134,12 @@ class Test(object):
         f = F(platform__in=["linux", "mock"])
         filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
 
-        assert filtered == ["dev3.group_2", "dev4.group_2", "dev5.no_group"]
+        assert filtered == [
+            "dev3.group_2",
+            "dev4.group_2",
+            "dev5.no_group",
+            "dev6.group_3",
+        ]
 
     def test_filtering_list_any(self, nornir):
         f = F(nested_data__a_list__any=[1, 3])

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -118,7 +118,7 @@ class Test(object):
                 "group_3": {
                     "connection_options": {},
                     "data": {"site": "site2"},
-                    "groups": [],
+                    "groups": ["dummy_group", "parent_group"],
                     "hostname": None,
                     "name": "group_3",
                     "password": "docker",
@@ -145,11 +145,26 @@ class Test(object):
                             "username": None,
                         },
                     },
-                    "data": {"a_false_var": False, "a_var": "blah"},
+                    "data": {
+                        "a_false_var": False,
+                        "a_var": "blah",
+                        "my_var": "comes_from_parent_group",
+                    },
                     "groups": [],
                     "hostname": None,
                     "name": "parent_group",
                     "password": "from_parent_group",
+                    "platform": "linux",
+                    "port": None,
+                    "username": "root",
+                },
+                "dummy_group": {
+                    "connection_options": {},
+                    "data": {},
+                    "groups": [],
+                    "hostname": None,
+                    "name": "dummy_group",
+                    "password": "docker",
                     "platform": "linux",
                     "port": None,
                     "username": "root",
@@ -287,6 +302,17 @@ class Test(object):
                     "port": 65024,
                     "username": "root",
                 },
+                "dev6.group_3": {
+                    "connection_options": {},
+                    "data": {"asd": 1},
+                    "groups": ["group_3"],
+                    "hostname": "localhost",
+                    "name": "dev6.group_3",
+                    "password": "docker",
+                    "platform": "linux",
+                    "port": 65025,
+                    "username": "root",
+                },
             },
         }
 
@@ -298,6 +324,7 @@ class Test(object):
             "dev3.group_2",
             "dev4.group_2",
             "dev5.no_group",
+            "dev6.group_3",
         ]
 
         www = sorted(list(inv.filter(role="www").hosts.keys()))
@@ -315,7 +342,7 @@ class Test(object):
         long_names = sorted(
             list(inv.filter(filter_func=lambda x: len(x["my_var"]) > 20).hosts.keys())
         )
-        assert long_names == ["dev1.group_1", "dev4.group_2"]
+        assert long_names == ["dev1.group_1", "dev4.group_2", "dev6.group_3"]
 
         def longer_than(dev, length):
             return len(dev["my_var"]) > length
@@ -323,7 +350,7 @@ class Test(object):
         long_names = sorted(
             list(inv.filter(filter_func=longer_than, length=20).hosts.keys())
         )
-        assert long_names == ["dev1.group_1", "dev4.group_2"]
+        assert long_names == ["dev1.group_1", "dev4.group_2", "dev6.group_3"]
 
     def test_filter_unique_keys(self, inv):
         filtered = sorted(list(inv.filter(www_server="nginx").hosts.keys()))
@@ -334,6 +361,8 @@ class Test(object):
         assert inv.hosts["dev2.group_1"]["my_var"] == "comes_from_group_1"
         assert inv.hosts["dev3.group_2"]["my_var"] == "comes_from_defaults"
         assert inv.hosts["dev4.group_2"]["my_var"] == "comes_from_dev4.group_2"
+        assert inv.hosts["dev5.no_group"]["my_var"] == "comes_from_defaults"
+        assert inv.hosts["dev6.group_3"]["my_var"] == "comes_from_parent_group"
         assert inv.hosts["dev1.group_1"]["a_false_var"] is False
 
         assert inv.hosts["dev1.group_1"].data["my_var"] == "comes_from_dev1.group_1"
@@ -399,6 +428,7 @@ class Test(object):
             inv.hosts["dev1.group_1"],
             inv.hosts["dev2.group_1"],
             inv.hosts["dev4.group_2"],
+            inv.hosts["dev6.group_3"],
         }
 
         assert inv.children_of_group("group_1") == {
@@ -418,6 +448,7 @@ class Test(object):
             inv.hosts["dev1.group_1"],
             inv.hosts["dev2.group_1"],
             inv.hosts["dev4.group_2"],
+            inv.hosts["dev6.group_3"],
         }
 
         assert inv.children_of_group(inv.groups["group_1"]) == {

--- a/tests/core/test_processors.py
+++ b/tests/core/test_processors.py
@@ -104,6 +104,12 @@ class Test:
                     "completed": True,
                     "failed": False,
                 },
+                "dev6.group_3": {
+                    "completed": True,
+                    "failed": False,
+                    "started": True,
+                    "subtasks": {},
+                },
                 "completed": True,
             }
         }
@@ -206,6 +212,32 @@ class Test:
                     "failed": False,
                 },
                 "dev5.no_group": {
+                    "started": True,
+                    "subtasks": {
+                        "mock_task": {
+                            "started": True,
+                            "subtasks": {},
+                            "completed": True,
+                            "failed": False,
+                        },
+                        "mock_subsubtask": {
+                            "started": True,
+                            "subtasks": {
+                                "mock_task": {
+                                    "started": True,
+                                    "subtasks": {},
+                                    "completed": True,
+                                    "failed": False,
+                                }
+                            },
+                            "completed": True,
+                            "failed": False,
+                        },
+                    },
+                    "completed": True,
+                    "failed": False,
+                },
+                "dev6.group_3": {
                     "started": True,
                     "subtasks": {
                         "mock_task": {

--- a/tests/inventory_data/groups.yaml
+++ b/tests/inventory_data/groups.yaml
@@ -1,4 +1,5 @@
 ---
+dummy_group: {}
 parent_group:
     port:
     hostname:
@@ -6,6 +7,7 @@ parent_group:
     password: from_parent_group
     platform:
     data:
+        my_var: comes_from_parent_group
         a_var: blah
         a_false_var: false
     groups: []
@@ -54,7 +56,9 @@ group_3:
     username:
     password:
     platform:
-    groups: []
+    groups:
+    - dummy_group
+    - parent_group
     data:
         site: site2
     connection_options: {}

--- a/tests/inventory_data/hosts.yaml
+++ b/tests/inventory_data/hosts.yaml
@@ -119,3 +119,14 @@ dev5.no_group:
     data: {}
     groups: []
     connection_options: {}
+dev6.group_3:
+    port: 65025
+    hostname: localhost
+    username:
+    password:
+    platform: linux
+    data:
+        asd: 1
+    groups:
+    - group_3
+    connection_options: {}

--- a/tests/plugins/inventory/test_simple_inventory.py
+++ b/tests/plugins/inventory/test_simple_inventory.py
@@ -42,9 +42,9 @@ class Test:
                     "hostname": None,
                     "name": "group_1",
                     "password": "from_group1",
-                    "platform": "linux",
+                    "platform": None,
                     "port": None,
-                    "username": "root",
+                    "username": None,
                 },
                 "group_2": {
                     "connection_options": {},
@@ -52,10 +52,10 @@ class Test:
                     "groups": [],
                     "hostname": None,
                     "name": "group_2",
-                    "password": "docker",
-                    "platform": "linux",
+                    "password": None,
+                    "platform": None,
                     "port": None,
-                    "username": "root",
+                    "username": None,
                 },
                 "group_3": {
                     "connection_options": {},
@@ -63,10 +63,10 @@ class Test:
                     "groups": [],
                     "hostname": None,
                     "name": "group_3",
-                    "password": "docker",
-                    "platform": "linux",
+                    "password": None,
+                    "platform": None,
                     "port": None,
-                    "username": "root",
+                    "username": None,
                 },
                 "parent_group": {
                     "connection_options": {
@@ -92,9 +92,9 @@ class Test:
                     "hostname": None,
                     "name": "parent_group",
                     "password": "from_parent_group",
-                    "platform": "linux",
+                    "platform": None,
                     "port": None,
-                    "username": "root",
+                    "username": None,
                 },
             },
             "hosts": {
@@ -133,7 +133,7 @@ class Test:
                     "password": "a_password",
                     "platform": "eos",
                     "port": 65020,
-                    "username": "root",
+                    "username": None,
                 },
                 "dev2.group_1": {
                     "connection_options": {
@@ -165,10 +165,10 @@ class Test:
                     "groups": ["group_1"],
                     "hostname": "localhost",
                     "name": "dev2.group_1",
-                    "password": "from_group1",
+                    "password": None,
                     "platform": "junos",
                     "port": 65021,
-                    "username": "root",
+                    "username": None,
                 },
                 "dev3.group_2": {
                     "connection_options": {
@@ -185,10 +185,10 @@ class Test:
                     "groups": ["group_2"],
                     "hostname": "localhost",
                     "name": "dev3.group_2",
-                    "password": "docker",
+                    "password": None,
                     "platform": "linux",
                     "port": 65022,
-                    "username": "root",
+                    "username": None,
                 },
                 "dev4.group_2": {
                     "connection_options": {
@@ -213,10 +213,10 @@ class Test:
                     "groups": ["parent_group", "group_2"],
                     "hostname": "localhost",
                     "name": "dev4.group_2",
-                    "password": "from_parent_group",
+                    "password": None,
                     "platform": "linux",
                     "port": 65023,
-                    "username": "root",
+                    "username": None,
                 },
                 "dev5.no_group": {
                     "connection_options": {},
@@ -224,10 +224,10 @@ class Test:
                     "groups": [],
                     "hostname": "localhost",
                     "name": "dev5.no_group",
-                    "password": "docker",
+                    "password": None,
                     "platform": "linux",
                     "port": 65024,
-                    "username": "root",
+                    "username": None,
                 },
             },
         }

--- a/tests/plugins/processors/test_serial.py
+++ b/tests/plugins/processors/test_serial.py
@@ -31,7 +31,7 @@ class TestSerialRunner(object):
         nornir.with_runner(SerialRunner()).run(blocking_task, wait=0.5)
         t2 = datetime.datetime.now()
         delta = t2 - t1
-        assert delta.seconds == 2, delta
+        assert delta.seconds == 3, delta
 
     def test_failing_task_simple_singlethread(self, nornir):
         result = nornir.with_runner(SerialRunner()).run(failing_task_simple)


### PR DESCRIPTION
fixes #621 

When resolving data nornir would start climbing up the tree until reach the defaults, however, the desired behaviour was to climb the tree and then back down for the next group before checking reaching the defaults, which should be checked only as a last resort.

For instance, with the tree below:
```
         host
     g1       g2
  g11 g12
        defaults
```

Before the behaviour was `host -> g1 -> g11 -> defaults` and now it is `host -> g1 -> g11 -> g12 -> g2 -> defaults`

In addition, this introduces two new methods:

1. `extended_data`, which returns the data of a given host or group, including its inherited data
2. `extended_groups`, which includes a list of groups the host or group belongs to including its inherited groups

Finally, the `dict` method was resolving the attributes of the hosts and groups, which wasn't supposed to happen, it's been fixed