### PR TITLE
Update simple.py,fix win10 UnicodeDecodeError

### DIFF
--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -92,14 +92,14 @@ class SimpleInventory:
         yml = ruamel.yaml.YAML(typ="safe")
 
         if self.defaults_file.exists():
-            with open(self.defaults_file, "r") as f:
+            with open(self.defaults_file, "rb") as f:
                 defaults_dict = yml.load(f) or {}
             defaults = _get_defaults(defaults_dict)
         else:
             defaults = Defaults()
 
         hosts = Hosts()
-        with open(self.host_file, "r") as f:
+        with open(self.host_file, "rb") as f:
             hosts_dict = yml.load(f)
 
         for n, h in hosts_dict.items():
@@ -107,7 +107,7 @@ class SimpleInventory:
 
         groups = Groups()
         if self.group_file.exists():
-            with open(self.group_file, "r") as f:
+            with open(self.group_file, "rb") as f:
                 groups_dict = yml.load(f) or {}
 
             for n, g in groups_dict.items():


### PR DESCRIPTION
fix win10 UnicodeDecodeError
```    
    nr = InitNornir(config_file="config.yaml")
  File "d:\python38\lib\site-packages\nornir\init_nornir.py", line 64, in InitNornir
    inventory=load_inventory(config),
  File "d:\python38\lib\site-packages\nornir\init_nornir.py", line 18, in load_inventory
    inv = inventory_plugin(**config.inventory.options).load()
  File "d:\python38\lib\site-packages\nornir\plugins\inventory\simple.py", line 103, in load
    hosts_dict = yml.load(f)
  File "d:\python38\lib\site-packages\ruamel\yaml\main.py", line 343, in load
    return constructor.get_single_data()
  File "d:\python38\lib\site-packages\ruamel\yaml\constructor.py", line 111, in get_single_data
    node = self.composer.get_single_node()
  File "_ruamel_yaml.pyx", line 701, in _ruamel_yaml.CParser.get_single_node
  File "_ruamel_yaml.pyx", line 902, in _ruamel_yaml.CParser._parse_next_event
  File "_ruamel_yaml.pyx", line 911, in _ruamel_yaml.input_handler
UnicodeDecodeError: 'gbk' codec can't decode byte 0xac in position 11744: illegal multibyte sequence