### PR TITLE
connection_options extra gathering in a merged way

### DIFF
--- a/nornir/core/helpers/__init__.py
+++ b/nornir/core/helpers/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional, MutableMapping
 
 
 def merge_two_dicts(x: Dict[Any, Any], y: Dict[Any, Any]) -> Dict[Any, Any]:
@@ -8,3 +8,31 @@ def merge_two_dicts(x: Dict[Any, Any], y: Dict[Any, Any]) -> Dict[Any, Any]:
         z = dict(x)
     z.update(y)
     return z
+
+
+def nested_update(
+    dct: Optional[MutableMapping[Any, Any]], upd: Optional[MutableMapping[Any, Any]]
+) -> None:
+    """
+    Nested update of dict-like 'dct' with dict-like 'upd'.
+
+    This function merges 'upd' into 'dct' even with nesting.
+    By the same keys, the values will be overwritten.
+
+    :param dct: Dictionary-like to update
+    :param upd: Dictionary-like to update with
+    :return: None
+    """
+    # update with dict-likes only
+    if not isinstance(dct, MutableMapping) or not isinstance(upd, MutableMapping):
+        return
+
+    for key in upd:
+        if (
+            key in dct
+            and isinstance(dct[key], MutableMapping)
+            and isinstance(upd[key], MutableMapping)
+        ):
+            nested_update(dct[key], upd[key])
+        else:
+            dct[key] = upd[key]

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -18,7 +18,12 @@ class Test(object):
         f = F(site="site1") | F(role="www")
         filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
 
-        assert filtered == ["dev1.group_1", "dev2.group_1", "dev3.group_2"]
+        assert filtered == [
+            "dev1.group_1",
+            "dev2.group_1",
+            "dev3.group_2",
+            "dev7.group_4",
+        ]
 
     def test_combined(self, nornir):
         f = F(site="site2") | (F(role="www") & F(my_var="comes_from_dev1.group_1"))
@@ -51,6 +56,7 @@ class Test(object):
             "dev4.group_2",
             "dev5.no_group",
             "dev6.group_3",
+            "dev7.group_4",
         ]
 
     def test_negate_and_second_negate(self, nornir):
@@ -69,6 +75,7 @@ class Test(object):
             "dev4.group_2",
             "dev5.no_group",
             "dev6.group_3",
+            "dev7.group_4",
         ]
 
     def test_nested_data_a_string(self, nornir):
@@ -105,6 +112,7 @@ class Test(object):
             "dev4.group_2",
             "dev5.no_group",
             "dev6.group_3",
+            "dev7.group_4",
         ]
 
     def test_nested_data_a_list_contains(self, nornir):
@@ -122,6 +130,7 @@ class Test(object):
             "dev2.group_1",
             "dev4.group_2",
             "dev6.group_3",
+            "dev7.group_4",
         ]
 
     def test_filtering_by_attribute_name(self, nornir):
@@ -139,6 +148,7 @@ class Test(object):
             "dev4.group_2",
             "dev5.no_group",
             "dev6.group_3",
+            "dev7.group_4",
         ]
 
     def test_filtering_string_any(self, nornir):

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -129,6 +129,26 @@ class Test(object):
                     "port": None,
                     "username": None,
                 },
+                "group_4": {
+                    "connection_options": {
+                        "dummy": {
+                            "extras": {"blah3": "from_group_4"},
+                            "hostname": None,
+                            "password": None,
+                            "platform": None,
+                            "port": None,
+                            "username": None,
+                        },
+                    },
+                    "data": {},
+                    "groups": ["parent_group"],
+                    "hostname": None,
+                    "name": "group_4",
+                    "password": None,
+                    "platform": None,
+                    "port": None,
+                    "username": None,
+                },
                 "parent_group": {
                     "connection_options": {
                         "dummy": {
@@ -318,6 +338,26 @@ class Test(object):
                     "port": 65025,
                     "username": None,
                 },
+                "dev7.group_4": {
+                    "connection_options": {
+                        "dummy": {
+                            "extras": {"blah4": "from_host_7"},
+                            "hostname": None,
+                            "password": None,
+                            "platform": None,
+                            "port": None,
+                            "username": None,
+                        }
+                    },
+                    "data": {"asd": 1, "role": "www"},
+                    "groups": ["group_4"],
+                    "hostname": "localhost",
+                    "name": "dev7.group_4",
+                    "password": None,
+                    "platform": "linux",
+                    "port": 65026,
+                    "username": None,
+                },
             },
         }
 
@@ -382,10 +422,11 @@ class Test(object):
             "dev4.group_2",
             "dev5.no_group",
             "dev6.group_3",
+            "dev7.group_4",
         ]
 
         www = sorted(list(inv.filter(role="www").hosts.keys()))
-        assert www == ["dev1.group_1", "dev3.group_2"]
+        assert www == ["dev1.group_1", "dev3.group_2", "dev7.group_4"]
 
         www_site1 = sorted(list(inv.filter(role="www", site="site1").hosts.keys()))
         assert www_site1 == ["dev1.group_1"]
@@ -399,7 +440,12 @@ class Test(object):
         long_names = sorted(
             list(inv.filter(filter_func=lambda x: len(x["my_var"]) > 20).hosts.keys())
         )
-        assert long_names == ["dev1.group_1", "dev4.group_2", "dev6.group_3"]
+        assert long_names == [
+            "dev1.group_1",
+            "dev4.group_2",
+            "dev6.group_3",
+            "dev7.group_4",
+        ]
 
         def longer_than(dev, length):
             return len(dev["my_var"]) > length
@@ -407,7 +453,12 @@ class Test(object):
         long_names = sorted(
             list(inv.filter(filter_func=longer_than, length=20).hosts.keys())
         )
-        assert long_names == ["dev1.group_1", "dev4.group_2", "dev6.group_3"]
+        assert long_names == [
+            "dev1.group_1",
+            "dev4.group_2",
+            "dev6.group_3",
+            "dev7.group_4",
+        ]
 
     def test_filter_unique_keys(self, inv):
         filtered = sorted(list(inv.filter(www_server="nginx").hosts.keys()))
@@ -472,6 +523,14 @@ class Test(object):
         assert p4.password == "docker"
         assert p4.platform == "linux"
         assert p4.extras == {"blah": "from_defaults"}
+        p5 = inv.hosts["dev7.group_4"].get_connection_parameters("dummy")
+        assert p5.port == 65026
+        assert p5.platform == "linux"
+        assert p5.extras == {
+            "blah": "from_group",
+            "blah3": "from_group_4",
+            "blah4": "from_host_7",
+        }
 
     def test_defaults(self, inv):
         inv.defaults.password = "asd"
@@ -487,6 +546,7 @@ class Test(object):
             inv.hosts["dev2.group_1"],
             inv.hosts["dev4.group_2"],
             inv.hosts["dev6.group_3"],
+            inv.hosts["dev7.group_4"],
         }
 
         assert inv.children_of_group("group_1") == {
@@ -507,6 +567,7 @@ class Test(object):
             inv.hosts["dev2.group_1"],
             inv.hosts["dev4.group_2"],
             inv.hosts["dev6.group_3"],
+            inv.hosts["dev7.group_4"],
         }
 
         assert inv.children_of_group(inv.groups["group_1"]) == {

--- a/tests/core/test_processors.py
+++ b/tests/core/test_processors.py
@@ -110,6 +110,12 @@ class Test:
                     "started": True,
                     "subtasks": {},
                 },
+                "dev7.group_4": {
+                    "completed": True,
+                    "failed": False,
+                    "started": True,
+                    "subtasks": {},
+                },
                 "completed": True,
             }
         }
@@ -238,6 +244,32 @@ class Test:
                     "failed": False,
                 },
                 "dev6.group_3": {
+                    "started": True,
+                    "subtasks": {
+                        "mock_task": {
+                            "started": True,
+                            "subtasks": {},
+                            "completed": True,
+                            "failed": False,
+                        },
+                        "mock_subsubtask": {
+                            "started": True,
+                            "subtasks": {
+                                "mock_task": {
+                                    "started": True,
+                                    "subtasks": {},
+                                    "completed": True,
+                                    "failed": False,
+                                }
+                            },
+                            "completed": True,
+                            "failed": False,
+                        },
+                    },
+                    "completed": True,
+                    "failed": False,
+                },
+                "dev7.group_4": {
                     "started": True,
                     "subtasks": {
                         "mock_task": {

--- a/tests/inventory_data/groups.yaml
+++ b/tests/inventory_data/groups.yaml
@@ -63,3 +63,21 @@ group_3:
     data:
         site: site2
     connection_options: {}
+group_4:
+    port:
+    hostname:
+    username:
+    password:
+    platform:
+    groups:
+    - parent_group
+    data:
+    connection_options:
+        dummy:
+            hostname:
+            port:
+            username:
+            password:
+            platform:
+            extras:
+                blah3: from_group_4

--- a/tests/inventory_data/hosts.yaml
+++ b/tests/inventory_data/hosts.yaml
@@ -132,3 +132,23 @@ dev6.group_3:
     groups:
     - group_3
     connection_options: {}
+dev7.group_4:
+    port: 65026
+    hostname: localhost
+    username:
+    password:
+    platform: linux
+    data:
+        asd: 1
+        role: www
+    groups:
+    - group_4
+    connection_options:
+        dummy:
+            hostname:
+            port:
+            username:
+            password:
+            platform:
+            extras:
+                blah4: from_host_7


### PR DESCRIPTION
Rewrote `get_connection_options` logic in a way that `defaults`, `group` and `host` `connection_options.extra` parameters will be merged. Priority is `defaults` -> `group1`, `group2`,... -> `host`
So a host defined extra parameter would override defaults or groups if the key is the same. All distinct parameters will be merged together.

### Benefits
We can better segment our `connection_options` extra parameters. We can define partial extras in defaults, groups and hosts.

### Downside of the new logic
If a user relies on that host defined extra will not merge but replace the default/groups, then the user might get additional parameters which might be unexpected.

### Example
defaults.yaml:
```
---
connection_options:
    netmiko:
        extras:
              secret: nornir
```

hosts.yaml:
```
host1:
    connection_options:
        netmiko:
            extras:
                  port: 222
```
#### Old behavior
This will result in that host1 will **NOT** have the `secret` parameter. Host file **replace** the extras.

#### New behavior
host1 will have set the port 222 and the secret set as well. Host file will **merge** the extras.

### TODO
Although I completed tests with the new behavior, I did not do production testing. I'm curious if this all would be interesting to merge into the project. If there is a chance, then I'd work on:

* more comprehensive tests with more realistic inventory
* Complete docs on the behavior. (Currently there is no docs at all on this part of the inventory, not even for the original behavior)