### PR TITLE
Removing jinja2 leftover from configuration

### DIFF
--- a/nornir/core/configuration.py
+++ b/nornir/core/configuration.py
@@ -245,7 +245,6 @@ class Config(object):
         "runner",
         "ssh",
         "inventory",
-        "jinja2",
         "logging",
         "user_defined",
     )


### PR DESCRIPTION
I think jinja2 is a leftover from version 2