### PR TITLE
Fix wrongly return True when a comparison returns NotImplemented

### DIFF
--- a/nornir/core/filter.py
+++ b/nornir/core/filter.py
@@ -65,7 +65,7 @@ class F(F_BASE):
         elif len(rule) == 1:
             operator = "__{}__".format(rule[0])
             if hasattr(data, operator):
-                return bool(getattr(data, operator)(value))
+                return getattr(data, operator)(value) is True
 
             elif hasattr(data, rule[0]):
                 if callable(getattr(data, rule[0])):

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -164,3 +164,9 @@ class Test(object):
         filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
 
         assert filtered == []
+
+    def test_eq__on_not_existing_key(self, nornir):
+        f = F(not_existing__eq="test")
+        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+
+        assert filtered == []


### PR DESCRIPTION
My teammate @zwiy discovered the following issue:

Using the F filter on a not existing data key. All hosts will be returned by the filter.

```
    def test_eq__on_not_existing_key(self, nornir):
        f = F(not_existing__eq="test")
        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
    
>       assert filtered == []
E       AssertionError: assert ['dev1.group_1',\n 'dev2.group_1',\n 'dev3.group_2',\n 'dev4.group_2',\n 'dev5.no_group',\n 'dev6.group_3'] == []
E         Left contains 6 more items, first extra item: 'dev1.group_1'
E         Full diff:
E           [
E         -  ,
E         +  'dev1.group_1',
E         +  'dev2.group_1',
E         +  'dev3.group_2',
E         +  'dev4.group_2',
E         +  'dev5.no_group',
E         +  'dev6.group_3',
E           ]
````

The issue was the dict object, returning a NotIplemented comparing a "string" with a dict

```
>>> {}.__eq__({})
True
>>> {}.__eq__("string")
NotImplemented
>>> {}.__eq__(123)
NotImplemented
>>> type({}.__eq__(123))
<class 'NotImplementedType'>
>>>
>>> bool({}.__eq__(123))
True
>>>
```


