### PR TITLE
Fix broken "Configuration" link

### DIFF
--- a/docs/tutorial/initializing_nornir.ipynb
+++ b/docs/tutorial/initializing_nornir.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "With `InitNornir` you can initialize nornir with a configuration file, with code or with a combination of both.\n",
     "\n",
-    "Let's start with [a configuration file](../../configuration/index.rst):"
+    "Let's start with [a configuration file](../configuration/index.rst):"
    ]
   },
   {


### PR DESCRIPTION
Addresses #807 
I ran across this myself when reading through the tutorials last week.  I _think_ this fixes it, but I am running into docs issues.  It looks like `make sphinx` is a WIP.  While I'm on the docs subject, `make start_dev_env` mentioned in "Contributing" doesn't exist in the Makefile on `main`, either.  I'm happy to address that here or on other PR.

```shell
poetry run sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
Skipping virtualenv creation, as specified in config file.
Running Sphinx v4.5.0
making output directory... done

Warning, treated as error:
The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
```