### PR TITLE
Fix pylama breakage (pep8 reference no longer works)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,15 +10,15 @@ universal=1
 # E731: do not assign a lambda expression, use a def
 # D10?: missing docstrings
 [pylama]
-linters = mccabe,pep8,pyflakes
-ignore = D203,C901
+linters = mccabe,pycodestyle,pyflakes
+ignore = D203,C901,W503
 skip = .tox/*,.venv/*,nornir/_vendor/*
 
-[pylama:pep8]
+[pylama:pycodestyle]
 max_line_length = 100
 
 [pycodestyle]
-ignore = D203,C901
+ignore = D203,C901,W503
 exclude = .git,__pycache__,build,dist
 max-complexity = 10
 max-line-length = 100


### PR DESCRIPTION
It came to my attention on both the NAPALM and Netmiko repositories that pylama . no longer worked (for calling the linter).

Basically 'pycodestyle (pep8)' was no longer executed and it would just silently pass (even when you had linting issues). This update should fix this.