### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "nornir"
-version = "3.3.0"
+version = "3.4.0"
 description = "Pluggable multi-threaded framework with inventory management to help operate collections of devices"
 authors = ["David Barroso <dbarrosop@dravetech.com>"]
 license = "Apache 2.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ filterwarnings =
 
 [mypy]
 # The mypy configurations: http://bit.ly/2zEl9WI
-python_version = 3.7
+python_version = 3.8
 check_untyped_defs = True
 disallow_any_generics = True
 disallow_untyped_calls = True


### PR DESCRIPTION
It was a while since the last release and at work we are creating a Nornir plugin for our product but due to how the dependencies were setup for mypy-extensions in Nornir 3.3.0 I'm running into an issue when trying to add the latest version of mypy:

```bash
❯ poetry add --group dev mypy=1.5.1

Updating dependencies
Resolving dependencies... (0.0s)

Because mypy (1.5.1) depends on mypy-extensions (>=1.0.0)
 and nornir (3.3.0) depends on mypy_extensions (>=0.4.1,<0.5.0), mypy (1.5.1) is incompatible with nornir (3.3.0).
And because no versions of nornir match >3.3.0,<4.0.0, mypy (1.5.1) is incompatible with nornir (>=3.3.0,<4.0.0).
```

This problem has already been fixed in the `main` branch, so it would be great if we could release a new version.

Also bumped the Python version in setup.cfg as 3.7 was dropped.