### PR TITLE
Change to Python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ What Nornir brings to the table is that it takes care of dealing with your inven
 Install
 =======
 
-Please note that Nornir requires Python 3.7 or higher. Install Nornir with pip.
+Please note that Nornir requires Python 3.8 or higher. Install Nornir with pip.
 
 ```
 pip install nornir

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ as the Flask of automation. Nornir will take care of dealing with the inventory 
 have your host information, it will take care of dispatching the tasks to your devices and
 will provide a common framework to write "plugins".
 
-Nornir requires Python 3.7 or higher to be installed.
+Nornir requires Python 3.8 or higher to be installed.
 
 How the documentation is structured
 ===================================


### PR DESCRIPTION
As per pyproject.toml Python 3.8 is the lowest version supported today, so removing the mention of 3.7.