### PR TITLE
Add changed() for AggregatedResult

### DIFF
--- a/nornir/core/task.py
+++ b/nornir/core/task.py
@@ -300,6 +300,11 @@ class AggregatedResult(Dict[str, MultiResult]):
         """Hosts that failed during the execution of the task."""
         return {h: r for h, r in self.items() if r.failed}
 
+    @property
+    def changed(self) -> bool:
+        """If ``True`` at least a host changed the system."""
+        return any([h.changed for h in self.values()])
+
     def raise_on_error(self) -> None:
         """
         Raises:


### PR DESCRIPTION
Hi,

Found myself in need for checking whether a subset of tasks run on multiple hosts returns any changes on any of the hosts.

This is so that I can just check for the returned `bool` and continue operation based on that.

The property exists for `MultiResult`, but didn't for `AggregatedResult`.