### PR TITLE
Proposal to support Async inventory 

### DIFF
--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import asyncio
+
 from nornir.core import Nornir
 from nornir.core.configuration import Config
 from nornir.core.inventory import Inventory
@@ -15,17 +17,36 @@ from nornir.core.state import GlobalState
 def load_inventory(
     config: Config,
 ) -> Inventory:
+    return asyncio.run(load_inventory_async(config=config))
+
+
+async def load_inventory_async(
+    config: Config,
+) -> Inventory:
     InventoryPluginRegister.auto_register()
     inventory_plugin = InventoryPluginRegister.get_plugin(config.inventory.plugin)
-    inv = inventory_plugin(**config.inventory.options).load()
+    inventory = inventory_plugin(**config.inventory.options)
+    if asyncio.iscoroutinefunction(inventory.load):
+        inv = await inventory.load()
+    else:
+        inv = inventory.load()
 
     if config.inventory.transform_function:
         TransformFunctionRegister.auto_register()
         transform_function = TransformFunctionRegister.get_plugin(
             config.inventory.transform_function
         )
-        for h in inv.hosts.values():
-            transform_function(h, **(config.inventory.transform_function_options or {}))
+
+        if asyncio.iscoroutinefunction(transform_function):
+            for h in inv.hosts.values():
+                await transform_function(
+                    h, **(config.inventory.transform_function_options or {})
+                )
+        else:
+            for h in inv.hosts.values():
+                transform_function(
+                    h, **(config.inventory.transform_function_options or {})
+                )
 
     return inv
 
@@ -39,7 +60,7 @@ def load_runner(
     return runner
 
 
-def InitNornir(
+async def InitNornirAsync(
     config_file: str = "",
     dry_run: bool = False,
     **kwargs: Any,
@@ -69,8 +90,31 @@ def InitNornir(
     config.logging.configure()
 
     return Nornir(
-        inventory=load_inventory(config),
+        inventory=await load_inventory_async(config),
         runner=load_runner(config),
         config=config,
         data=data,
+    )
+
+
+def InitNornir(
+    config_file: str = "",
+    dry_run: bool = False,
+    **kwargs: Any,
+) -> Nornir:
+    """
+    Arguments:
+        config_file(str): Path to the configuration file (optional)
+        dry_run(bool): Whether to simulate changes or not
+        configure_logging: Whether to configure logging or not. This argument is being
+            deprecated. Please use logging.enabled parameter in the configuration
+            instead.
+        **kwargs: Extra information to pass to the
+            :obj:`nornir.core.configuration.Config` object
+
+    Returns:
+        :obj:`nornir.core.Nornir`: fully instantiated and configured
+    """
+    return asyncio.run(
+        InitNornirAsync(config_file=config_file, dry_run=dry_run, **kwargs)
     )

--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -123,3 +123,7 @@ class SimpleInventory:
             h.groups = ParentGroups([groups[g] for g in h.groups])
 
         return Inventory(hosts=hosts, groups=groups, defaults=defaults)
+
+class SimpleInventoryAsync(SimpleInventory):
+    async def load(self) -> Inventory:
+        return super().load()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry.plugins."nornir.plugins.inventory"]
 "SimpleInventory" = "nornir.plugins.inventory.simple:SimpleInventory"
+"SimpleInventoryAsync" = "nornir.plugins.inventory.simple:SimpleInventoryAsync"
 
 [tool.poetry]
 name = "nornir"


### PR DESCRIPTION
Related to #880 

This PR is an example of implementation of how Nornir could support both sync and async inventory without much effort and without having to duplicate the code.

The main idea is to have the main code written in Async and wrap these functions with asyncio.run to also support non async execution.