### PR TITLE
WIP: Inventory data plugin

### DIFF
--- a/nornir/core/configuration.py
+++ b/nornir/core/configuration.py
@@ -111,6 +111,30 @@ class InventoryConfig(object):
         }
 
 
+class InventoryDataConfig(object):
+    __slots__ = "plugin", "options"
+
+    class Parameters:
+        plugin = Parameter(
+            typ=str, default="InventoryDataDict", envvar="NORNIR_INVENTORY_DATA_PLUGIN"
+        )
+        options = Parameter(default={}, envvar="NORNIR_INVENTORY_DATA_OPTIONS")
+
+    def __init__(
+        self,
+        plugin: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.plugin = self.Parameters.plugin.resolve(plugin)
+        self.options = self.Parameters.options.resolve(options) or {}
+
+    def dict(self) -> Dict[str, Any]:
+        return {
+            "plugin": self.plugin,
+            "options": self.options,
+        }
+
+
 class LoggingConfig(object):
     __slots__ = "enabled", "level", "log_file", "format", "to_console", "loggers"
 
@@ -245,6 +269,7 @@ class Config(object):
         "runner",
         "ssh",
         "inventory",
+        "inventory_data",
         "logging",
         "user_defined",
     )
@@ -252,6 +277,7 @@ class Config(object):
     def __init__(
         self,
         inventory: Optional[InventoryConfig] = None,
+        inventory_data: Optional[InventoryConfig] = None,
         ssh: Optional[SSHConfig] = None,
         logging: Optional[LoggingConfig] = None,
         core: Optional[CoreConfig] = None,
@@ -259,6 +285,7 @@ class Config(object):
         user_defined: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.inventory = inventory or InventoryConfig()
+        self.inventory_data = inventory_data or InventoryDataConfig()
         self.ssh = ssh or SSHConfig()
         self.logging = logging or LoggingConfig()
         self.core = core or CoreConfig()
@@ -269,6 +296,7 @@ class Config(object):
     def from_dict(
         cls,
         inventory: Optional[Dict[str, Any]] = None,
+        inventory_data: Optional[Dict[str, Any]] = None,
         ssh: Optional[Dict[str, Any]] = None,
         logging: Optional[Dict[str, Any]] = None,
         core: Optional[Dict[str, Any]] = None,
@@ -277,6 +305,7 @@ class Config(object):
     ) -> "Config":
         return cls(
             inventory=InventoryConfig(**inventory or {}),
+            inventory_data=InventoryDataConfig(**inventory_data or {}),
             ssh=SSHConfig(**ssh or {}),
             logging=LoggingConfig(**logging or {}),
             core=CoreConfig(**core or {}),
@@ -289,6 +318,7 @@ class Config(object):
         cls,
         config_file: str,
         inventory: Optional[Dict[str, Any]] = None,
+        inventory_data: Optional[Dict[str, Any]] = None,
         ssh: Optional[Dict[str, Any]] = None,
         logging: Optional[Dict[str, Any]] = None,
         core: Optional[Dict[str, Any]] = None,
@@ -296,6 +326,7 @@ class Config(object):
         user_defined: Optional[Dict[str, Any]] = None,
     ) -> "Config":
         inventory = inventory or {}
+        inventory_data = inventory_data or {}
         ssh = ssh or {}
         logging = logging or {}
         core = core or {}
@@ -306,6 +337,9 @@ class Config(object):
             data = yml.load(f)
         return cls(
             inventory=InventoryConfig(**{**data.get("inventory", {}), **inventory}),
+            inventory_data=InventoryDataConfig(
+                **{**data.get("inventory_data", {}), **inventory_data}
+            ),
             ssh=SSHConfig(**{**data.get("ssh", {}), **ssh}),
             logging=LoggingConfig(**{**data.get("logging", {}), **logging}),
             core=CoreConfig(**{**data.get("core", {}), **core}),
@@ -316,6 +350,7 @@ class Config(object):
     def dict(self) -> Dict[str, Any]:
         return {
             "inventory": self.inventory.dict(),
+            "inventory_data": self.inventory_data.dict(),
             "ssh": self.ssh.dict(),
             "logging": self.logging.dict(),
             "core": self.core.dict(),

--- a/nornir/core/configuration.py
+++ b/nornir/core/configuration.py
@@ -277,7 +277,7 @@ class Config(object):
     def __init__(
         self,
         inventory: Optional[InventoryConfig] = None,
-        inventory_data: Optional[InventoryConfig] = None,
+        inventory_data: Optional[InventoryDataConfig] = None,
         ssh: Optional[SSHConfig] = None,
         logging: Optional[LoggingConfig] = None,
         core: Optional[CoreConfig] = None,

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -8,7 +8,6 @@ from typing import (
     Optional,
     Protocol,
     Set,
-    Type,
     TypeVar,
     Union,
     ValuesView,
@@ -26,8 +25,8 @@ HostOrGroup = TypeVar("HostOrGroup", "Host", "Group")
 
 
 def _init_inventory_data(
-    data: Optional[Dict[str, Any]], configuration: Optional[Config] = None
-) -> Type[InventoryData]:
+    data: Optional[Dict[str, Any]] = None, configuration: Optional[Config] = None
+) -> Union[Dict[str, Any], InventoryData]:
     if not configuration:
         configuration = Config()
     InventoryDataPluginRegister.auto_register()

--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -8,6 +8,7 @@ from typing import (
     Optional,
     Protocol,
     Set,
+    Type,
     TypeVar,
     Union,
     ValuesView,
@@ -16,8 +17,24 @@ from typing import (
 from nornir.core.configuration import Config
 from nornir.core.exceptions import ConnectionAlreadyOpen, ConnectionNotOpen
 from nornir.core.plugins.connections import ConnectionPlugin, ConnectionPluginRegister
+from nornir.core.plugins.inventory_data import (
+    InventoryData,
+    InventoryDataPluginRegister,
+)
 
 HostOrGroup = TypeVar("HostOrGroup", "Host", "Group")
+
+
+def _init_inventory_data(
+    data: Optional[Dict[str, Any]], configuration: Optional[Config] = None
+) -> Type[InventoryData]:
+    if not configuration:
+        configuration = Config()
+    InventoryDataPluginRegister.auto_register()
+    inventory_data_plugin = InventoryDataPluginRegister.get_plugin(
+        configuration.inventory_data.plugin
+    )
+    return inventory_data_plugin(**configuration.inventory_data.options).load(data)
 
 
 class BaseAttributes(object):
@@ -125,9 +142,10 @@ class InventoryElement(BaseAttributes):
         groups: Optional[ParentGroups] = None,
         data: Optional[Dict[str, Any]] = None,
         connection_options: Optional[Dict[str, ConnectionOptions]] = None,
+        configuration: Optional[Config] = None,
     ) -> None:
         self.groups = groups or ParentGroups()
-        self.data = data or {}
+        self.data = _init_inventory_data(data, configuration=configuration)
         self.connection_options = connection_options or {}
         super().__init__(
             hostname=hostname,
@@ -208,8 +226,9 @@ class Defaults(BaseAttributes):
         platform: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
         connection_options: Optional[Dict[str, ConnectionOptions]] = None,
+        configuration: Optional[Config] = None,
     ) -> None:
-        self.data = data or {}
+        self.data = _init_inventory_data(data, configuration=configuration)
         self.connection_options = connection_options or {}
         super().__init__(
             hostname=hostname,
@@ -252,6 +271,7 @@ class Host(InventoryElement):
         data: Optional[Dict[str, Any]] = None,
         connection_options: Optional[Dict[str, ConnectionOptions]] = None,
         defaults: Optional[Defaults] = None,
+        configuration: Optional[Config] = None,
     ) -> None:
         self.name = name
         self.defaults = defaults or Defaults(None, None, None, None, None, None, None)
@@ -265,6 +285,7 @@ class Host(InventoryElement):
             groups=groups,
             data=data,
             connection_options=connection_options,
+            configuration=configuration,
         )
 
     def extended_data(self) -> Dict[str, Any]:

--- a/nornir/core/plugins/inventory_data.py
+++ b/nornir/core/plugins/inventory_data.py
@@ -1,4 +1,14 @@
-from typing import Any, Dict, ItemsView, KeysView, Protocol, Type, ValuesView
+from typing import (
+    Any,
+    Dict,
+    ItemsView,
+    KeysView,
+    Optional,
+    Protocol,
+    Type,
+    Union,
+    ValuesView,
+)
 
 from nornir.core.plugins.register import PluginRegister
 
@@ -12,37 +22,37 @@ class InventoryData(Protocol):
         """
         raise NotImplementedError("needs to be implemented by the plugin")
 
-    def __getitem__(self, key) -> Any:
+    def __getitem__(self, key: str) -> Any:
         """
         This method configures the plugin
         """
         raise NotImplementedError("needs to be implemented by the plugin")
 
-    def get(self, key, default=None) -> Any:
+    def get(self, key: str, default: Any = None) -> Any:
         """
         This method configures the plugin
         """
         raise NotImplementedError("needs to be implemented by the plugin")
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any) -> None:
         """
         This method configures the plugin
         """
         raise NotImplementedError("needs to be implemented by the plugin")
 
-    def keys(self) -> KeysView:
+    def keys(self) -> KeysView[str]:
         """
         This method configures the plugin
         """
         raise NotImplementedError("needs to be implemented by the plugin")
 
-    def values(self) -> ValuesView:
+    def values(self) -> ValuesView[Any]:
         """
         This method configures the plugin
         """
         raise NotImplementedError("needs to be implemented by the plugin")
 
-    def items(self) -> ItemsView:
+    def items(self) -> ItemsView[str, Any]:
         """
         This method configures the plugin
         """
@@ -56,7 +66,9 @@ class InventoryDataPlugin(Protocol):
         """
         raise NotImplementedError("needs to be implemented by the plugin")
 
-    def load(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def load(
+        self, data: Optional[Dict[str, Any]] = None
+    ) -> Union[Dict[str, Any], InventoryData]:
         """
         Returns the object containing the data
         """

--- a/nornir/core/plugins/inventory_data.py
+++ b/nornir/core/plugins/inventory_data.py
@@ -1,0 +1,68 @@
+from typing import Any, Dict, ItemsView, KeysView, Protocol, Type, ValuesView
+
+from nornir.core.plugins.register import PluginRegister
+
+INVENTORY_DATA_PLUGIN_PATH = "nornir.plugins.inventory_data"
+
+
+class InventoryData(Protocol):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+    def __getitem__(self, key) -> Any:
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+    def get(self, key, default=None) -> Any:
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+    def __setitem__(self, key, value):
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+    def keys(self) -> KeysView:
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+    def values(self) -> ValuesView:
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+    def items(self) -> ItemsView:
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+
+class InventoryDataPlugin(Protocol):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        This method configures the plugin
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+    def load(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Returns the object containing the data
+        """
+        raise NotImplementedError("needs to be implemented by the plugin")
+
+
+InventoryDataPluginRegister: PluginRegister[Type[InventoryDataPlugin]] = PluginRegister(
+    INVENTORY_DATA_PLUGIN_PATH
+)

--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -24,8 +24,8 @@ def load_inventory(
     if "configuration" in init_params:
         config_parameter = init_params["configuration"]
         if config_parameter.annotation is not inspect.Parameter.empty and (
-            config_parameter.annotation is Config
-            or Union[config_parameter.annotation, None] is Config
+            config_parameter.annotation == Config
+            or config_parameter.annotation == Union[Config, None]
         ):
             inventory_plugin_params.update({"configuration": config})
 

--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any
+from typing import Any, Union
 
 from nornir.core import Nornir
 from nornir.core.configuration import Config
@@ -23,8 +23,9 @@ def load_inventory(
     init_params = inspect.signature(inventory_plugin).parameters
     if "configuration" in init_params:
         config_parameter = init_params["configuration"]
-        if config_parameter is not inspect.Parameter.empty and issubclass(
-            config_parameter.annotation, Config
+        if config_parameter.annotation is not inspect.Parameter.empty and (
+            config_parameter.annotation is Config
+            or Union[config_parameter.annotation, None] is Config
         ):
             inventory_plugin_params.update({"configuration": config})
 

--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -34,7 +34,9 @@ def _get_connection_options(data: Dict[str, Any]) -> Dict[str, ConnectionOptions
     return cp
 
 
-def _get_defaults(data: Dict[str, Any], configuration: Optional[Config] = None) -> Defaults:
+def _get_defaults(
+    data: Dict[str, Any], configuration: Optional[Config] = None
+) -> Defaults:
     return Defaults(
         hostname=data.get("hostname"),
         port=data.get("port"),
@@ -115,7 +117,9 @@ class SimpleInventory:
             hosts_dict = yml.load(f)
 
         for n, h in hosts_dict.items():
-            hosts[n] = _get_inventory_element(Host, h, n, defaults, configuration=self._config)
+            hosts[n] = _get_inventory_element(
+                Host, h, n, defaults, configuration=self._config
+            )
 
         groups = Groups()
         if self.group_file.exists():

--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -1,9 +1,10 @@
 import logging
 import pathlib
-from typing import Any, Dict, Type
+from typing import Any, Dict, Optional, Type
 
 import ruamel.yaml
 
+from nornir.core.configuration import Config
 from nornir.core.inventory import (
     ConnectionOptions,
     Defaults,
@@ -33,7 +34,7 @@ def _get_connection_options(data: Dict[str, Any]) -> Dict[str, ConnectionOptions
     return cp
 
 
-def _get_defaults(data: Dict[str, Any]) -> Defaults:
+def _get_defaults(data: Dict[str, Any], configuration: Optional[Config] = None) -> Defaults:
     return Defaults(
         hostname=data.get("hostname"),
         port=data.get("port"),
@@ -42,11 +43,16 @@ def _get_defaults(data: Dict[str, Any]) -> Defaults:
         platform=data.get("platform"),
         data=data.get("data"),
         connection_options=_get_connection_options(data.get("connection_options", {})),
+        configuration=configuration,
     )
 
 
 def _get_inventory_element(
-    typ: Type[HostOrGroup], data: Dict[str, Any], name: str, defaults: Defaults
+    typ: Type[HostOrGroup],
+    data: Dict[str, Any],
+    name: str,
+    defaults: Defaults,
+    configuration: Optional[Config] = None,
 ) -> HostOrGroup:
     return typ(
         name=name,
@@ -61,6 +67,7 @@ def _get_inventory_element(
         ),  # this is a hack, we will convert it later to the correct type
         defaults=defaults,
         connection_options=_get_connection_options(data.get("connection_options", {})),
+        configuration=configuration,
     )
 
 
@@ -71,6 +78,7 @@ class SimpleInventory:
         group_file: str = "groups.yaml",
         defaults_file: str = "defaults.yaml",
         encoding: str = "utf-8",
+        configuration: Optional[Config] = None,
     ) -> None:
         """
         SimpleInventory is an inventory plugin that loads data from YAML files.
@@ -90,6 +98,7 @@ class SimpleInventory:
         self.group_file = pathlib.Path(group_file).expanduser()
         self.defaults_file = pathlib.Path(defaults_file).expanduser()
         self.encoding = encoding
+        self._config = configuration
 
     def load(self) -> Inventory:
         yml = ruamel.yaml.YAML(typ="safe")
@@ -97,7 +106,7 @@ class SimpleInventory:
         if self.defaults_file.exists():
             with open(self.defaults_file, "r", encoding=self.encoding) as f:
                 defaults_dict = yml.load(f) or {}
-            defaults = _get_defaults(defaults_dict)
+            defaults = _get_defaults(defaults_dict, configuration=self._config)
         else:
             defaults = Defaults()
 
@@ -106,7 +115,7 @@ class SimpleInventory:
             hosts_dict = yml.load(f)
 
         for n, h in hosts_dict.items():
-            hosts[n] = _get_inventory_element(Host, h, n, defaults)
+            hosts[n] = _get_inventory_element(Host, h, n, defaults, configuration=self._config)
 
         groups = Groups()
         if self.group_file.exists():
@@ -114,7 +123,9 @@ class SimpleInventory:
                 groups_dict = yml.load(f) or {}
 
             for n, g in groups_dict.items():
-                groups[n] = _get_inventory_element(Group, g, n, defaults)
+                groups[n] = _get_inventory_element(
+                    Group, g, n, defaults, configuration=self._config
+                )
 
             for g in groups.values():
                 g.groups = ParentGroups([groups[g] for g in g.groups])

--- a/nornir/plugins/inventory_data/__init__.py
+++ b/nornir/plugins/inventory_data/__init__.py
@@ -1,0 +1,3 @@
+from .dictionary import InventoryDataDict
+
+__all__ = ("InventoryDataDict",)

--- a/nornir/plugins/inventory_data/dictionary.py
+++ b/nornir/plugins/inventory_data/dictionary.py
@@ -1,0 +1,22 @@
+import logging
+from typing import Any, Dict, Optional
+
+from nornir.core.plugins.inventory_data import InventoryData
+
+logger = logging.getLogger(__name__)
+
+
+class InventoryDataDict:
+    def __init__(self) -> None:
+        """
+        This method configures the plugin
+        """
+        ...
+
+    def load(self, data: Optional[Dict[str, Any]]) -> InventoryData:
+        """
+        Returns the object containing the data
+        """
+        if data is None:
+            return dict()
+        return data

--- a/nornir/plugins/inventory_data/dictionary.py
+++ b/nornir/plugins/inventory_data/dictionary.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from nornir.core.plugins.inventory_data import InventoryData
 
@@ -13,7 +13,9 @@ class InventoryDataDict:
         """
         ...
 
-    def load(self, data: Optional[Dict[str, Any]]) -> InventoryData:
+    def load(
+        self, data: Optional[Dict[str, Any]]
+    ) -> Union[Dict[str, Any], InventoryData]:
         """
         Returns the object containing the data
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ build-backend = "poetry.masonry.api"
 [tool.poetry.plugins."nornir.plugins.inventory"]
 "SimpleInventory" = "nornir.plugins.inventory.simple:SimpleInventory"
 
+[tool.poetry.plugins."nornir.plugins.inventory_data"]
+"InventoryDataDict" = "nornir.plugins.inventory_data.dictionary:InventoryDataDict"
+
 [tool.poetry]
 name = "nornir"
 version = "3.4.1"

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -25,6 +25,10 @@ class Test(object):
                 "transform_function": "",
                 "transform_function_options": {},
             },
+            "inventory_data": {
+                "plugin": "InventoryDataDict",
+                "options": {},
+            },
             "ssh": {"config_file": str(Path("~/.ssh/config").expanduser())},
             "logging": {
                 "enabled": True,
@@ -48,6 +52,10 @@ class Test(object):
                 "transform_function": "",
                 "transform_function_options": {},
             },
+            "inventory_data": {
+                "plugin": "InventoryDataDict",
+                "options": {},
+            },
             "ssh": {"config_file": str(Path("~/.ssh/config").expanduser())},
             "logging": {
                 "enabled": True,
@@ -63,6 +71,7 @@ class Test(object):
     def test_config_basic(self):
         c = Config.from_dict(
             inventory={"plugin": "an-inventory"},
+            inventory_data={"plugin": "an-inventory_data"},
             runner={"plugin": "serial", "options": {"a": 1, "b": 2}},
             logging={"log_file": ""},
             user_defined={"my_opt": True},
@@ -73,6 +82,10 @@ class Test(object):
                 "options": {},
                 "transform_function": "",
                 "transform_function_options": {},
+            },
+            "inventory_data": {
+                "plugin": "an-inventory_data",
+                "options": {},
             },
             "runner": {"options": {"a": 1, "b": 2}, "plugin": "serial"},
             "ssh": {"config_file": str(Path("~/.ssh/config").expanduser())},

--- a/tests/core/test_inventory_data.py
+++ b/tests/core/test_inventory_data.py
@@ -1,0 +1,188 @@
+# import os
+
+# import pytest
+# import ruamel.yaml
+
+from typing import Any, Dict, ItemsView, KeysView, ValuesView
+
+from nornir.core import inventory
+from nornir.core.configuration import Config, InventoryDataConfig
+from nornir.core.plugins.inventory_data import InventoryDataPluginRegister
+
+# yaml = ruamel.yaml.YAML(typ="safe")
+# dir_path = os.path.dirname(os.path.realpath(__file__))
+# with open(f"{dir_path}/../inventory_data/hosts.yaml") as f:
+#     hosts = yaml.load(f)
+# with open(f"{dir_path}/../inventory_data/groups.yaml") as f:
+#     groups = yaml.load(f)
+# with open(f"{dir_path}/../inventory_data/defaults.yaml") as f:
+#     defaults = yaml.load(f)
+# inv_dict = {"hosts": hosts, "groups": groups, "defaults": defaults}
+
+
+class MockInventoryData:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self.data = data
+
+    def __getitem__(self, key) -> Any:
+        """
+        This method configures the plugin
+        """
+        return self.data[key]
+
+    def get(self, key, default=None) -> Any:
+        """
+        This method configures the plugin
+        """
+        return self.data.get(key, default)
+
+    def __setitem__(self, key, value):
+        """
+        This method configures the plugin
+        """
+        self.data[key] = value
+
+    def keys(self) -> KeysView:
+        """
+        This method configures the plugin
+        """
+        return self.data.keys()
+
+    def values(self) -> ValuesView:
+        """
+        This method configures the plugin
+        """
+        return self.data.values()
+
+    def items(self) -> ItemsView:
+        """
+        This method configures the plugin
+        """
+        return self.data.items()
+
+
+class MockInventoryDataPlugin:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        This method configures the plugin
+        """
+        ...
+
+    def load(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Returns the object containing the data
+        """
+        return MockInventoryData(data=data)
+
+
+class Test(object):
+    @classmethod
+    def setup_class(cls):
+        InventoryDataPluginRegister.deregister_all()
+        InventoryDataPluginRegister.register(
+            "MockInventoryDataPlugin", MockInventoryDataPlugin
+        )
+
+    def test_host(self):
+        config = Config(
+            inventory_data=InventoryDataConfig(plugin="MockInventoryDataPlugin")
+        )
+        h = inventory.Host(
+            name="host1",
+            hostname="host1",
+            data={"test": "test123"},
+            configuration=config,
+        )
+        assert h.hostname == "host1"
+        assert isinstance(h.data, MockInventoryData)
+        assert h.data["test"] == "test123"
+        assert h.get("test") == "test123"
+
+    def test_group(self):
+        config = Config(
+            inventory_data=InventoryDataConfig(plugin="MockInventoryDataPlugin")
+        )
+        g = inventory.Group(
+            name="group1", data={"test": "test123"}, configuration=config
+        )
+        assert g.name == "group1"
+        assert isinstance(g.data, MockInventoryData)
+        assert g.data["test"] == "test123"
+        assert g.data.get("test") == "test123"
+
+    def test_default(self):
+        config = Config(
+            inventory_data=InventoryDataConfig(plugin="MockInventoryDataPlugin")
+        )
+        d = inventory.Defaults(data={"test": "test123"}, configuration=config)
+        assert isinstance(d.data, MockInventoryData)
+        assert d.data["test"] == "test123"
+        assert d.data.get("test") == "test123"
+
+    def test_inventory_data(self):
+        config = Config(
+            inventory_data=InventoryDataConfig(plugin="MockInventoryDataPlugin")
+        )
+        g1 = inventory.Group(
+            name="g1", data={"g1": "group1 data"}, configuration=config
+        )
+        g2 = inventory.Group(
+            name="g2",
+            groups=inventory.ParentGroups([g1]),
+            data={"g2": "group2 data"},
+            configuration=config,
+        )
+        h1 = inventory.Host(
+            name="h1",
+            groups=inventory.ParentGroups([g1, g2]),
+            data={"host_data": "host 1"},
+            configuration=config,
+        )
+        h2 = inventory.Host(
+            name="h2", data={"host_data": "host 2"}, configuration=config
+        )
+        hosts = {"h1": h1, "h2": h2}
+        groups = {"g1": g1, "g2": g2}
+        inv = inventory.Inventory(hosts=hosts, groups=groups)
+
+        assert list(inv.hosts["h2"].keys()) == ["host_data"]
+        assert "host_data" in inv.hosts["h1"].keys()
+        assert "g1" in inv.hosts["h1"].keys()
+        assert "g2" in inv.hosts["h1"].keys()
+        assert len(inv.hosts["h1"].items()) == 3
+        assert len(inv.hosts["h1"].values()) == 3
+
+        assert inv.hosts["h1"].get("host_data") == "host 1"
+        assert inv.hosts["h1"].get("g1") == "group1 data"
+        assert inv.hosts["h1"].get("g2") == "group2 data"
+
+        assert inv.hosts["h1"].extended_data() == {
+            "host_data": "host 1",
+            "g1": "group1 data",
+            "g2": "group2 data",
+        }
+        assert inv.hosts["h2"].extended_data() == {
+            "host_data": "host 2",
+        }
+
+    def test_inventory_data_default(self):
+        config = Config(
+            inventory_data=InventoryDataConfig(plugin="MockInventoryDataPlugin")
+        )
+        d = inventory.Defaults(data={"default": "default data"}, configuration=config)
+        h1 = inventory.Host(
+            name="h1", data={"host_data": "host 1"}, defaults=d, configuration=config
+        )
+        hosts = {"h1": h1}
+        inv = inventory.Inventory(hosts=hosts, defaults=d)
+
+        assert inv.hosts["h1"].get("host_data") == "host 1"
+        assert inv.hosts["h1"].get("default") == "default data"
+        assert len(inv.hosts["h1"].keys()) == 2
+        assert len(inv.hosts["h1"].items()) == 2
+        assert len(inv.hosts["h1"].values()) == 2
+
+        assert inv.hosts["h1"].extended_data() == {
+            "host_data": "host 1",
+            "default": "default data",
+        }


### PR DESCRIPTION
This pull request is a quick and incomplete implementation of adding an Inventory Data Plugin. The idea is to have a base to discuss this idea and what would be needed to accept such a change.

At the moment, the inventory data is stored in a Python dictionary. This works great. However, I found myself in a situation where I would like to replace the dictionary with objects. More specifically, I would like to use a pydantic model for the data structure. Firstly, to have input validation and, secondly, to be able to add functions to the pedantic objects to reduce logic in templates.

This PR adds a new plugin type called InventoryDataPlugin. The idea is to allow the default dict object to be replaced with another object. For now, I implemented it in a way that does not break any tests, as the new datatype used to store the data needs to provide methods similar to a dictionary. The code and plugin are most likely more complex because of this.

To use pydantic I would try to implement a plugin to use a model similar to this (just "random" pseudocode, untested):
```python
from typing import (
    Any,
    ItemsView,
    KeysView,
    ValuesView,
)

from pydantic import BaseModel, ConfigDict
from pydantic.networks import IPvAnyAddress

class User(BaseModel):
    model_config = ConfigDict(
        strict=True
    )
    name: str
    age: int
    is_active: bool
    ip: IPvAnyAddress

    def __getitem__(self, key: str) -> Any:
        return getattr(self, key)
    
    def get(self, key: str, default: Any = None) -> Any:
        try:
            return self.__getitem__(key)
        except AttributeError:
            return default
    
    def __setitem__(self, key: str, value: Any):
        self.model_validate({**self.__dict__, **{key: value}})
        setattr(self, key, value)
    
    def keys(self) -> KeysView[str]:
        return self.__dict__.keys()
    
    def values(self) -> ValuesView[Any]:
        return self.__dict__.values()
    
    def items(self) -> ItemsView[str, Any]:
        return self.__dict__.items()

```

The model, of course, would be much more complex with nested models. What already works well is to store multiple models in the data dictionary. So, in this case, only the first level would be a dictionary. 