### PR TITLE
Add property for optional runner

### DIFF
--- a/nornir/core/__init__.py
+++ b/nornir/core/__init__.py
@@ -47,7 +47,7 @@ class Nornir(object):
         self.inventory = inventory
         self.config = config or Config()
         self.processors = processors or Processors()
-        self.runner = runner
+        self._runner = runner
 
     def __enter__(self) -> "Nornir":
         return self
@@ -65,14 +65,16 @@ class Nornir(object):
         Given a list of Processor objects return a copy of the nornir object with the processors
         assigned to the copy. The orinal object is left unmodified.
         """
-        return Nornir(**{**self.__dict__, **{"processors": Processors(processors)}})
+        return Nornir(
+            **{**self._clone_parameters(), **{"processors": Processors(processors)}}
+        )
 
     def with_runner(self, runner: RunnerPlugin) -> "Nornir":
         """
         Given a runner return a copy of the nornir object with the runner
         assigned to the copy. The orinal object is left unmodified.
         """
-        return Nornir(**{**self.__dict__, **{"runner": runner}})
+        return Nornir(**{**self._clone_parameters(), **{"runner": runner}})
 
     def filter(self, *args: Any, **kwargs: Any) -> "Nornir":
         """
@@ -81,7 +83,7 @@ class Nornir(object):
         Returns:
             :obj:`Nornir`: A new object with same configuration as ``self`` but filtered inventory.
         """
-        b = Nornir(**self.__dict__)
+        b = Nornir(**self._clone_parameters())
         b.inventory = self.inventory.filter(*args, **kwargs)
         return b
 
@@ -143,7 +145,7 @@ class Nornir(object):
         else:
             logger.warning("Task %r has not been run – 0 hosts selected", task.name)
 
-        result = self._runner.run(task, run_on)
+        result = self.runner.run(task, run_on)
 
         raise_on_error = (
             raise_on_error
@@ -170,11 +172,20 @@ class Nornir(object):
         self.run(task=close_connections_task, on_good=on_good, on_failed=on_failed)
 
     @property
-    def _runner(self) -> RunnerPlugin:
-        if self.runner:
-            return self.runner
+    def runner(self) -> RunnerPlugin:
+        if self._runner:
+            return self._runner
 
         raise PluginNotRegistered("Runner plugin not registered")
+
+    def _clone_parameters(self) -> Dict[str, Any]:
+        return {
+            "data": self.data,
+            "inventory": self.inventory,
+            "config": self.config,
+            "processors": self.processors,
+            "runner": self._runner,
+        }
 
     @classmethod
     def get_validators(cls) -> Generator[Callable[["Nornir"], "Nornir"], None, None]:

--- a/nornir/core/__init__.py
+++ b/nornir/core/__init__.py
@@ -4,6 +4,7 @@ import types
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Type
 
 from nornir.core.configuration import Config
+from nornir.core.exceptions import PluginNotRegistered
 from nornir.core.inventory import Inventory
 from nornir.core.plugins.runners import RunnerPlugin
 from nornir.core.processor import Processor, Processors
@@ -142,7 +143,7 @@ class Nornir(object):
         else:
             logger.warning("Task %r has not been run – 0 hosts selected", task.name)
 
-        result = self.runner.run(task, run_on)
+        result = self._runner.run(task, run_on)
 
         raise_on_error = (
             raise_on_error
@@ -167,6 +168,13 @@ class Nornir(object):
             task.host.close_connections()
 
         self.run(task=close_connections_task, on_good=on_good, on_failed=on_failed)
+
+    @property
+    def _runner(self) -> RunnerPlugin:
+        if self.runner:
+            return self.runner
+
+        raise PluginNotRegistered("Runner plugin not registered")
 
     @classmethod
     def get_validators(cls) -> Generator[Callable[["Nornir"], "Nornir"], None, None]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ warn_redundant_casts = True
 [mypy-nornir.core]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
-strict_optional = False
 
 [mypy-tests.*]
 ignore_errors = True


### PR DESCRIPTION
The `runner` argument to Nornir is defined as being optional but we later use it as if it's always set. Adding a property that returns a `RunnerPlugin` or raises an error, with this we can also remove the `strict_optional = False` bypass in the mypy config.
