### PR TITLE
Move section for commented out code, remove shebang

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # nornir documentation build configuration file, created by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,6 @@ ignore = [
     "B028",    # No explicit `stacklevel` keyword argument found
     "C419",    # Unnecessary list comprehension
     "COM812",  # Trailing comma missing
-    "ERA001",  # Found commented-out code
-    "EXE001",  # Shebang is present but file is not executable
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition
     "FURB101", # `open` and `read` should be replaced by `Path(filename).read_text()`
@@ -197,7 +195,8 @@ max-returns = 11
 [tool.ruff.lint.per-file-ignores]
 
 "docs/conf.py" = [
-    "A001", # Variable `copyright` is shadowing a Python builtin
+    "A001",   # Variable `copyright` is shadowing a Python builtin
+    "ERA001", # Commented out code, used to provide examples for Sphinx docs
 ]
 
 "docs/highlighter.py" = [


### PR DESCRIPTION
Move global rule for commented out code to only apply to docs/conf.py, remove shebang in docs/conf.py as the file is not executable.