### PR TITLE
Fix Ruff PYI036 - Type annotations for context manager exit

### DIFF
--- a/nornir/core/__init__.py
+++ b/nornir/core/__init__.py
@@ -51,8 +51,8 @@ class Nornir:
 
     def __exit__(
         self,
-        exc_type: Type[BaseException],
-        exc_val: BaseException,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_val: Optional[BaseException] = None,
         exc_tb: Optional[types.TracebackType] = None,
     ) -> None:
         self.close_connections(on_good=True, on_failed=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ ignore = [
     "PTH100",  # `os.path.abspath()` should be replaced by `Path.resolve()`
     "PTH120",  # `os.path.dirname()` should be replaced by `Path.parent`
     "PTH123",  # `open()` should be replaced by `Path.open()`
-    "PYI036",  # The first argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
     "RET504",  # Unnecessary assignment before `return` statement
     "RSE102",  # Unnecessary parentheses on raised exception
     "RUF001",  # String contains ambiguous `–` (EN DASH). Did you mean `-` (HYPHEN-MINUS)?


### PR DESCRIPTION
The first argument in `__exit__` should be annotated with `object` or `type[BaseException] | None