### PR TITLE
Switch coverage badge from develop to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://github.com/nornir-automation/nornir/workflows/test%20nornir/badge.svg) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![Coverage Status](https://coveralls.io/repos/github/nornir-automation/nornir/badge.svg?branch=develop)](https://coveralls.io/github/nornir-automation/nornir?branch=develop)
+![Build Status](https://github.com/nornir-automation/nornir/workflows/test%20nornir/badge.svg) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![Coverage Status](https://coveralls.io/repos/github/nornir-automation/nornir/badge.svg?branch=main)](https://coveralls.io/github/nornir-automation/nornir?branch=main)
 
 
 Nornir


### PR DESCRIPTION
This is to reflect the current default branch on GitHub where the `develop` branch no longer exists.

Note, due to #935 this will cause the reported value to drop until that issue is fixed.