### PR TITLE
SECURITY.md - (minor) fix dependency spelling

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,4 +7,4 @@ Only latest version is supported.
 ## Reporting a Vulnerability
 
 To report a vulnerability feel free to reach out privately on [GitHub](https://github.com/nornir-automation/nornir/security/advisories/new) so we can fix before a public disclosure.
-If the issue is on a dependency feel free to open a PR bumping such depdency without contacting us first.
+If the issue is on a dependency feel free to open a PR bumping such dependency without contacting us first.


### PR DESCRIPTION
(minor) fix dependency spelling in `SECURITY.md`