### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/nornir/__init__.py
+++ b/nornir/__init__.py
@@ -1,7 +1,7 @@
-import pkg_resources
+from importlib.metadata import version
 
 from nornir.init_nornir import InitNornir
 
-__version__ = pkg_resources.get_distribution("nornir").version
+__version__ = version("nornir")
 
 __all__ = ("InitNornir", "__version__")


### PR DESCRIPTION
`pkg_resources` is deprecated in Python 3.12 (https://setuptools.pypa.io/en/latest/pkg_resources.html), and `importlib.metadata` is available since Python 3.8 (https://docs.python.org/3.12/library/importlib.metadata.html)