### PR TITLE
Fix coverage reporting

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,9 @@ jobs:
         if: ${{ matrix.platform != 'windows-2022' }}
 
       - name: Run pytest
-        run: uv run pytest --cov=nornir --cov-report=term-missing
+        run: |
+          uv run coverage run --source=nornir -m pytest
+          uv run coverage report -m
         if: ${{ matrix.platform == 'windows-2022' }}
 
       - name: Run nbval

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ docker:
 
 .PHONY: pytest
 pytest:
-	uv run pytest --cov=nornir --cov-report=term-missing --cov-report xml -vs ${ARGS}
+	uv run coverage run --source=nornir -m pytest -vs ${ARGS}
+	uv run coverage report -m
+	uv run coverage xml
 
 .PHONY: mypy
 mypy:


### PR DESCRIPTION
# Changes in this PR

Updates how we measure code coverage, there was a problem since `pytest-cov` preloaded Nornir due to the name "plugin" being used within the tests.

Fixes #935.
