### PR TITLE
fix(simple_inventory): handle empty inventory files gracefully

### DIFF
--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -97,8 +97,9 @@ class SimpleInventory:
                 defaults_dict = yml.load(f) or {}
             if defaults_dict == {}:
                 logger.warning(
-                    f"'{self.defaults_file}' is empty or contains only comments, "
-                    "defaulting to empty defaults."
+                    "'%s' is empty or contains only comments, "
+                    "defaulting to empty defaults.",
+                    self.defaults_file,
                 )
             defaults = _get_defaults(defaults_dict)
         else:
@@ -109,8 +110,9 @@ class SimpleInventory:
             hosts_dict = yml.load(f) or {}
         if hosts_dict == {}:
             logger.warning(
-                f"'{self.host_file}' is empty or contains only comments, "
-                "defaulting to empty hosts inventory."
+                "'%s' is empty or contains only comments, "
+                "defaulting to empty hosts inventory.",
+                self.host_file,
             )
 
         for n, h in hosts_dict.items():
@@ -122,8 +124,9 @@ class SimpleInventory:
                 groups_dict = yml.load(f) or {}
             if groups_dict == {}:
                 logger.warning(
-                    f"'{self.group_file}' is empty or contains only comments, "
-                    "defaulting to empty groups inventory."
+                    "'%s' is empty or contains only comments, "
+                    "defaulting to empty groups inventory.",
+                    self.group_file,
                 )
 
             for n, g in groups_dict.items():

--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -95,13 +95,23 @@ class SimpleInventory:
         if self.defaults_file.exists():
             with open(self.defaults_file, "r", encoding=self.encoding) as f:
                 defaults_dict = yml.load(f) or {}
+            if defaults_dict == {}:
+                logger.warning(
+                    f"'{self.defaults_file}' is empty or contains only comments, "
+                    "defaulting to empty defaults."
+                )
             defaults = _get_defaults(defaults_dict)
         else:
             defaults = Defaults()
 
         hosts = Hosts()
         with open(self.host_file, "r", encoding=self.encoding) as f:
-            hosts_dict = yml.load(f)
+            hosts_dict = yml.load(f) or {}
+        if hosts_dict == {}:
+            logger.warning(
+                f"'{self.host_file}' is empty or contains only comments, "
+                "defaulting to empty hosts inventory."
+            )
 
         for n, h in hosts_dict.items():
             hosts[n] = _get_inventory_element(Host, h, n, defaults)
@@ -110,6 +120,11 @@ class SimpleInventory:
         if self.group_file.exists():
             with open(self.group_file, "r", encoding=self.encoding) as f:
                 groups_dict = yml.load(f) or {}
+            if groups_dict == {}:
+                logger.warning(
+                    f"'{self.group_file}' is empty or contains only comments, "
+                    "defaulting to empty groups inventory."
+                )
 
             for n, g in groups_dict.items():
                 groups[n] = _get_inventory_element(Group, g, n, defaults)

--- a/tests/plugins/inventory/test_simple_inventory.py
+++ b/tests/plugins/inventory/test_simple_inventory.py
@@ -242,3 +242,14 @@ class Test:
         assert len(inv.hosts) == 1
         assert inv.groups == {}
         assert inv.defaults.data == {}
+
+    def test_simple_inventory_empty_hosts(self) -> None:
+        """Verify completely empty hosts.yaml doesn't generate exception."""
+        host_file = f"{dir_path}/data/hosts-empty.yaml"
+        group_file = f"{dir_path}/data/groups-empty.yaml"
+        defaults_file = f"{dir_path}/data/defaults-empty.yaml"
+
+        inv = SimpleInventory(host_file, group_file, defaults_file).load()
+        assert inv.hosts == {}
+        assert inv.groups == {}
+        assert inv.defaults.data == {}


### PR DESCRIPTION
Closes #1054

When hosts.yaml (or groups.yaml, defaults.yaml) is empty, ruamel.yaml.YAML.load() returns None. This caused an AttributeError when iterating over the result with .items().

This fix ensures that None is coalesced to an empty dict, consistent with how the other inventory files were already handled. A warning is logged when this happens so the user is aware.

Changes:
- Default hosts_dict to {} if yaml.load() returns None
- Add warning logs for empty inventory files
- Add test for completely empty hosts.yaml

All existing tests pass.