### PR TITLE
Remove if-condition and code for pre Python 3.10

### DIFF
--- a/nornir/core/plugins/register.py
+++ b/nornir/core/plugins/register.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-import sys
+from importlib import metadata
 from typing import Generic, TypeVar
 
 from nornir.core.exceptions import PluginAlreadyRegistered, PluginNotRegistered
-
-if sys.version_info >= (3, 10):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
-
 
 T = TypeVar("T")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,6 @@ ignore = [
     "UP015",   # Unnecessary open mode parameters
     "UP032",   # Use f-string instead of `format` call
     "UP034",   # Avoid extraneous parentheses
-    "UP036",   # Version block is outdated for minimum Python version
 ]
 
 [tool.ruff.format]


### PR DESCRIPTION
Fix ruff UP036 "Version block is outdated for minimum Python version". We had an if condition for another import when using Python 3.9 and below, but the project no longer supports Python 3.9.

Relates to #1059