### PR TITLE
Remove required Python versions and fix plugins link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ What Nornir brings to the table is that it takes care of dealing with your inven
 
 ## Install
 
-Please note that Nornir requires Python 3.10 or higher. Install Nornir with pip.
+ Install Nornir with pip.
 
 ```bash
 pip install nornir

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,6 @@ as the Flask of automation. Nornir will take care of dealing with the inventory 
 have your host information, it will take care of dispatching the tasks to your devices and
 will provide a common framework to write "plugins".
 
-Nornir requires Python 3.8 or higher to be installed.
-
 How the documentation is structured
 ===================================
 
@@ -26,7 +24,7 @@ How the documentation is structured
 - :doc:`How-to guides <howto/index>` aim to solve a specific use case or answer key problems. These guides can be more advanced than the tutorial and can assume some knowledge about how Nornir and related technologies work.
 - :doc:`The API section <api/index>` contains the API reference for Nornir and describe the core functions.
 - :doc:`Configuration <configuration/index>` describe the configuration parameters of Nornir and their default settings.
-- `nornir.tech <https://nornir.tech/nornir/plugins/>`_ is a good place to find plugins for nornir
+- The :doc:`Community plugins <community/plugin_list>` page is a good place to find plugins for Nornir.
 
 Is something missing from the documentation? Please open an issue and `tell us what you are missing <https://github.com/nornir-automation/nornir/issues>`_ or `open a pull request <https://github.com/nornir-automation/nornir/pulls>`_ and suggest an improvement.
 


### PR DESCRIPTION
### Changes in this PR

* Removes Python requirement from documentation, both for the top level readme and also the outdated one from the documentation. Seems like it's too easy to forget to update the versions when we phase out an old version of Python and I'm not sure I think it's relevant to list the Python version required in a .md or .rst file this is already captured in pyproject.toml as well as the metadata for the package itself.
* Also updates a broken link to the plugins.