### PR TITLE
Re-enable five flake8-pytest-style ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,11 +265,6 @@ max-returns = 11
     "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
     "PTH118",  # `os.path.join()` should be replaced by `Path` with `/` operator
     "PTH120",  # `os.path.dirname()` should be replaced by `Path.parent`
-    "PT003",   # `scope='function'` is implied in `@pytest.fixture()`
-    "PT006",   # Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
-    "PT012",   # `pytest.raises()` block should contain a single simple statement
-    "PT018",   # Assertion should be broken down into multiple parts
-    "PT011",   # `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
     "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,7 @@ def nornir() -> Nornir:
     return Nornir(inventory=inventory_from_yaml(), runner=SerialRunner(), data=global_data)
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(autouse=True)
 def reset_data() -> None:
     global_data.dry_run = True
     global_data.reset_failed_hosts()

--- a/tests/core/test_InitNornir.py
+++ b/tests/core/test_InitNornir.py
@@ -151,7 +151,7 @@ class Test:
 
     def test_InitNornir_different_transform_function_by_string_with_bad_options(self) -> None:
         with pytest.raises(TypeError):
-            nr = InitNornir(
+            InitNornir(
                 config_file=os.path.join(dir_path, "a_config.yaml"),
                 inventory={
                     "plugin": "inventory-test",
@@ -163,7 +163,6 @@ class Test:
                     },
                 },
             )
-            assert nr
 
 
 class TestLogging:

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -175,7 +175,7 @@ class Test:
         assert filtered == []
 
     @pytest.mark.parametrize(
-        "filter_a,filter_b",
+        ("filter_a", "filter_b"),
         [
             (F(), F()),
             (F(site="site1") & F(role="www"), AND(F(site="site1"), F(role="www"))),
@@ -188,7 +188,7 @@ class Test:
         assert filter_a == filter_b
 
     @pytest.mark.parametrize(
-        "filter_a,filter_b",
+        ("filter_a", "filter_b"),
         [
             (OR(F(site="site1"), F(role="www")), AND(F(site="site1"), F(role="www"))),
             (F(site="site1"), F(role="www")),

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -573,8 +573,10 @@ class Test:
         assert isinstance(inventory_dict, dict)
         assert inventory_dict["defaults"]["username"] == "root"
         assert def_extras["blah"] == "from_defaults"
-        assert "my_var" and "site" in grp_data
-        assert "www_server" and "role" in host_data
+        assert "my_var" in grp_data
+        assert "site" in grp_data
+        assert "www_server" in host_data
+        assert "role" in host_data
 
     def test_get_defaults_dict(self, inv: inventory.Inventory) -> None:
         defaults_dict = inv.defaults.dict()
@@ -643,5 +645,5 @@ class Test:
         assert h1.get("var3", None) is None
         assert h1.get("var1", None) == "val1"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="x not in list"):
             h1.groups.remove(g3)


### PR DESCRIPTION
Continues the work from #1068, which enabled all ruff rules and parked the new violations in a temporary ignore list. This PR takes five of the `flake8-pytest-style` rules off that list and fixes the seven violations they were suppressing.

Rules re-enabled, all from the `"tests/**.py"` per-file-ignores block in `pyproject.toml`:

- `PT003` - `scope='function'` is implied in `@pytest.fixture()`
- `PT006` - wrong type passed to first argument of `@pytest.mark.parametrize`
- `PT011` - `pytest.raises(ValueError)` is too broad
- `PT012` - `pytest.raises()` block should contain a single simple statement
- `PT018` - assertion should be broken down into multiple parts

## One of these was hiding a real bug

`tests/core/test_inventory.py::Test::test_dict` contained:

```python
assert "my_var" and "site" in grp_data
assert "www_server" and "role" in host_data
```

Python parses that as `assert "my_var" and ("site" in grp_data)`. A non-empty
string literal is always truthy, so `my_var` and `www_server` were never
actually checked - each line only ever asserted the second key. The assertions
have been split so all four keys are tested. All four keys are in fact present
in the fixture inventory, so nothing was broken; the coverage was just
fictional.

This is the argument for burning down the rest of the ignore list: `PT018`
is filed under style, but composite assertions silently narrow what a test
verifies.

## The rest are mechanical

| File | Change |
|---|---|
| `tests/conftest.py:132` | Dropped the redundant `scope="function"` from the `reset_data` fixture |
| `tests/core/test_filter.py:178,191` | `"filter_a,filter_b"` -> `("filter_a", "filter_b")` in two `parametrize` calls |
| `tests/core/test_InitNornir.py:153` | Removed a dead `nr = ` assignment and trailing `assert nr` from inside a `pytest.raises` block - `InitNornir` raises before either could run |
| `tests/core/test_inventory.py:646` | Added `match=` to a broad `pytest.raises(ValueError)` |

## One thing worth a second opinion

The `PT011` fix asserts against a stdlib message:

```python
with pytest.raises(ValueError, match="x not in list"):
    h1.groups.remove(g3)
```

`ParentGroups` subclasses `list`, so this `ValueError` comes from
`list.remove`, not from nornir - the full message is
`list.remove(x): x not in list`. That means the test is now coupled to
CPython's wording. I used the shortest stable substring to limit the
exposure, but it is still an external contract, and it is the only `match=`
in the suite (8 `pytest.raises` calls, this is the first with one).

The cleaner long-term fix would be for `ParentGroups.remove` to raise a
nornir-specific exception, but that is a behavior change and would break
anyone currently catching `ValueError`, so it felt out of scope for a lint
cleanup. Happy to go another way if you would rather - including leaving
`PT011` on the ignore list for now and taking the other four.

## Verification

```
ruff check .            # All checks passed!
ruff format --check .   # 46 files already formatted
mypy tests/ nornir/     # Success: no issues found in 44 source files
pytest -q               # 118 passed
```

No production code touched - `nornir/` is unchanged, this is `pyproject.toml`
plus four test files.
