### PR TITLE
docs: fix typo in filtering deep dive

### DIFF
--- a/docs/howto/filtering_deep_dive.ipynb
+++ b/docs/howto/filtering_deep_dive.ipynb
@@ -640,7 +640,7 @@
    "id": "foster-timing",
    "metadata": {},
    "source": [
-    "Naturally over time, you needs to store custom data might change and ideally you enrich your custom data with as much business information as possible. \n",
+    "Naturally over time, your needs to store custom data might change and ideally you enrich your custom data with as much business information as possible. \n",
     "\n",
     "In the example below, a new set of key/value pairs related to the location of the site are now stored under the `location` key. This means that any existing code leveraging the existing data structure doesn't need to be refactored:"
    ]


### PR DESCRIPTION
## Summary

Correct `you needs` to `your needs` in the filtering deep-dive notebook.

This changes only the reported sentence and does not modify notebook metadata or outputs.

## Verification

- `python -m json.tool docs/howto/filtering_deep_dive.ipynb` — passed
- Confirmed one corrected occurrence and no remaining occurrence of the reported typo
- `uv run pytest -q` — 118 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 46 files already formatted
- `uv run mypy nornir tests` — passed

## Platform note

Targeted nbval execution on Windows completed 14 cells and failed 6 existing `%cat` cells because their expected stdout was missing. The edited Markdown cell is unrelated, and this PR does not modify executable cells or notebook outputs.

Fixes #993