### PR TITLE
ci: test wheel importability

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,28 +41,8 @@ jobs:
           python-version: "3.14"
           enable-cache: true
 
-      - name: Build wheel
-        run: uv build
-
-      - name: Install and import wheel
-        run: |
-          uv venv /tmp/nornir-wheel-test
-          uv pip install --python /tmp/nornir-wheel-test/bin/python dist/*.whl
-          cd /tmp
-          /tmp/nornir-wheel-test/bin/python -I - <<'PY'
-          import pathlib
-          import sys
-
-          import nornir
-          from nornir import InitNornir
-
-          module_path = pathlib.Path(nornir.__file__).resolve()
-          environment = pathlib.Path(sys.prefix).resolve()
-          if environment not in module_path.parents:
-              raise SystemExit(f"Imported nornir from outside {environment}: {module_path}")
-          if InitNornir.__name__ != "InitNornir":
-              raise SystemExit("InitNornir is not importable from the built wheel")
-          PY
+      - name: Build and import wheel
+        run: make wheel
 
   pytest:
     name: Testing on Python ${{ matrix.python-version }} (${{ matrix.platform}})

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,6 +30,40 @@ jobs:
           sudo apt-get install pandoc
           make docs
 
+  wheel:
+    name: Build and import wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: "3.14"
+          enable-cache: true
+
+      - name: Build wheel
+        run: uv build
+
+      - name: Install and import wheel
+        run: |
+          uv venv /tmp/nornir-wheel-test
+          uv pip install --python /tmp/nornir-wheel-test/bin/python dist/*.whl
+          cd /tmp
+          /tmp/nornir-wheel-test/bin/python -I - <<'PY'
+          import pathlib
+          import sys
+
+          import nornir
+          from nornir import InitNornir
+
+          module_path = pathlib.Path(nornir.__file__).resolve()
+          environment = pathlib.Path(sys.prefix).resolve()
+          if environment not in module_path.parents:
+              raise SystemExit(f"Imported nornir from outside {environment}: {module_path}")
+          if InitNornir.__name__ != "InitNornir":
+              raise SystemExit("InitNornir is not importable from the built wheel")
+          PY
+
   pytest:
     name: Testing on Python ${{ matrix.python-version }} (${{ matrix.platform}})
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ PYTHON:=3.10
 docker:
 	docker build --build-arg PYTHON=$(PYTHON) -t $(NAME):latest -f Dockerfile .
 
+.PHONY: wheel
+wheel:
+	uv build
+	uv run --no-project python tests/wheel_importability.py
+
 .PHONY: pytest
 pytest:
 	uv run coverage run --source=nornir -m pytest -vs ${ARGS}

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ docker:
 
 .PHONY: wheel
 wheel:
+	rm -rf dist
 	uv build
 	uv run --no-project python tests/wheel_importability.py
 

--- a/tests/test_wheel_importability.py
+++ b/tests/test_wheel_importability.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import pytest
+
+from tests.wheel_importability import find_built_wheel, find_environment_python
+
+
+def test_find_built_wheel_returns_the_only_wheel(tmp_path: Path) -> None:
+    wheel = tmp_path / "nornir-3.6.0-py3-none-any.whl"
+    wheel.write_bytes(b"wheel")
+
+    assert find_built_wheel(tmp_path) == wheel
+
+
+def test_find_built_wheel_rejects_missing_wheel(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match=r"exactly one wheel.*found 0"):
+        find_built_wheel(tmp_path)
+
+
+def test_find_built_wheel_rejects_multiple_wheels(tmp_path: Path) -> None:
+    (tmp_path / "first.whl").write_bytes(b"first")
+    (tmp_path / "second.whl").write_bytes(b"second")
+
+    with pytest.raises(RuntimeError, match=r"exactly one wheel.*found 2"):
+        find_built_wheel(tmp_path)
+
+
+def test_find_environment_python_supports_posix_layout(tmp_path: Path) -> None:
+    python = tmp_path / "bin" / "python"
+    python.parent.mkdir()
+    python.touch()
+
+    assert find_environment_python(tmp_path) == python
+
+
+def test_find_environment_python_supports_windows_layout(tmp_path: Path) -> None:
+    python = tmp_path / "Scripts" / "python.exe"
+    python.parent.mkdir()
+    python.touch()
+
+    assert find_environment_python(tmp_path) == python
+
+
+def test_find_environment_python_rejects_unknown_layout(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Unable to find Python"):
+        find_environment_python(tmp_path)

--- a/tests/wheel_importability.py
+++ b/tests/wheel_importability.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import shutil
+import subprocess  # noqa: S404
+import sys
+import tempfile
+from pathlib import Path
+
+IMPORT_CHECK = """
+import pathlib
+import sys
+
+import nornir
+from nornir import InitNornir
+
+module_path = pathlib.Path(nornir.__file__).resolve()
+environment = pathlib.Path(sys.prefix).resolve()
+if environment not in module_path.parents:
+    raise SystemExit(f"Imported nornir from outside {environment}: {module_path}")
+if InitNornir.__name__ != "InitNornir":
+    raise SystemExit("InitNornir is not importable from the built wheel")
+"""
+
+
+def find_built_wheel(dist_directory: Path) -> Path:
+    wheels = sorted(dist_directory.glob("*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"Expected exactly one wheel in {dist_directory}, found {len(wheels)}")
+    return wheels[0]
+
+
+def find_environment_python(environment: Path) -> Path:
+    candidates = (
+        environment / "bin" / "python",
+        environment / "Scripts" / "python.exe",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise RuntimeError(f"Unable to find Python in virtual environment {environment}")
+
+
+def run(command: tuple[str, ...], *, cwd: Path) -> None:
+    subprocess.run(command, cwd=cwd, check=True)  # noqa: S603
+
+
+def main() -> None:
+    repository = Path(__file__).resolve().parents[1]
+    wheel = find_built_wheel(repository / "dist")
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv is required to verify the built wheel")
+
+    with tempfile.TemporaryDirectory(prefix="nornir-wheel-test-") as temporary:
+        temporary_directory = Path(temporary)
+        environment = temporary_directory / "venv"
+        run((uv, "venv", str(environment)), cwd=repository)
+        python = find_environment_python(environment)
+        run(
+            (uv, "pip", "install", "--python", str(python), str(wheel)),
+            cwd=repository,
+        )
+
+        outside_checkout = temporary_directory / "outside-checkout"
+        outside_checkout.mkdir()
+        run((str(python), "-I", "-c", IMPORT_CHECK), cwd=outside_checkout)
+
+    sys.stdout.write(f"Verified isolated import from {wheel.name}\n")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (RuntimeError, subprocess.CalledProcessError) as exc:
+        sys.stderr.write(f"Wheel importability check failed: {exc}\n")
+        raise SystemExit(1) from exc


### PR DESCRIPTION
## Summary

- build the project wheel in CI with `uv build`
- install the wheel into a fresh virtual environment
- import `nornir` and `InitNornir` outside the source checkout
- verify that the imported module comes from the isolated environment

This adds regression coverage for packaging problems that can remain hidden when tests run with development dependencies or import directly from the repository.

## Verification

- GitHub Actions passed on the fork: 17/17 jobs
- the new `Build and import wheel` job passed on Ubuntu with Python 3.14
- a local negative control with an undeclared runtime import failed the same test as expected
- `uv run pytest -q`: 118 passed
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: passed
- `uv run mypy nornir tests`: passed
- actionlint: passed

Fixes #869