### PR TITLE
Re-enable the B007 and C414 ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,8 +255,6 @@ max-returns = 11
 # investigation if they are deemed to not make sense.                                            #
 ##################################################################################################
     "ARG001",  # Unused function argument
-    "B007",    # Loop control variable `host` not used within loop body
-    "C414",    # Unnecessary `list` call within `sorted()`
     "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
     "LOG009",  # Use of undocumented `logging.WARN` constant
     "N999",    # Invalid module name

--- a/tests/core/test_filter.py
+++ b/tests/core/test_filter.py
@@ -7,25 +7,25 @@ from nornir.core.filter import AND, OR, F
 class Test:
     def test_simple(self, nornir: Nornir) -> None:
         f = F(site="site1")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1", "dev2.group_1"]
 
     def test_and(self, nornir: Nornir) -> None:
         f = F(site="site1") & F(role="www")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1"]
 
     def test_or(self, nornir: Nornir) -> None:
         f = F(site="site1") | F(role="www")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1", "dev2.group_1", "dev3.group_2"]
 
     def test_combined(self, nornir: Nornir) -> None:
         f = F(site="site2") | (F(role="www") & F(my_var="comes_from_dev1.group_1"))
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == [
             "dev1.group_1",
@@ -35,19 +35,19 @@ class Test:
         ]
 
         f = (F(site="site2") | F(role="www")) & F(my_var="comes_from_dev1.group_1")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1"]
 
     def test_contains(self, nornir: Nornir) -> None:
         f = F(groups__contains="group_1")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1", "dev2.group_1"]
 
     def test_negate(self, nornir: Nornir) -> None:
         f = ~F(groups__contains="group_1")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == [
             "dev3.group_2",
@@ -58,13 +58,13 @@ class Test:
 
     def test_negate_and_second_negate(self, nornir: Nornir) -> None:
         f = F(site="site1") & ~F(role="www")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev2.group_1"]
 
     def test_negate_or_both_negate(self, nornir: Nornir) -> None:
         f = ~F(site="site1") | ~F(role="www")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == [
             "dev2.group_1",
@@ -76,31 +76,31 @@ class Test:
 
     def test_nested_data_a_string(self, nornir: Nornir) -> None:
         f = F(nested_data__a_string="asdasd")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1"]
 
     def test_nested_data_a_string_contains(self, nornir: Nornir) -> None:
         f = F(nested_data__a_string__contains="asd")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1"]
 
     def test_nested_data_a_dict_contains(self, nornir: Nornir) -> None:
         f = F(nested_data__a_dict__contains="a")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1"]
 
     def test_nested_data_a_dict_element(self, nornir: Nornir) -> None:
         f = F(nested_data__a_dict__a=1)
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1"]
 
     def test_nested_data_a_dict_doesnt_contain(self, nornir: Nornir) -> None:
         f = ~F(nested_data__a_dict__contains="a")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == [
             "dev2.group_1",
@@ -112,13 +112,13 @@ class Test:
 
     def test_nested_data_a_list_contains(self, nornir: Nornir) -> None:
         f = F(nested_data__a_list__contains=2)
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1", "dev2.group_1"]
 
     def test_filtering_by_callable_has_parent_group(self, nornir: Nornir) -> None:
         f = F(has_parent_group="parent_group")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == [
             "dev1.group_1",
@@ -129,13 +129,13 @@ class Test:
 
     def test_filtering_by_attribute_name(self, nornir: Nornir) -> None:
         f = F(name="dev1.group_1")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1"]
 
     def test_filtering_string_in_list(self, nornir: Nornir) -> None:
         f = F(platform__in=["linux", "mock"])
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == [
             "dev3.group_2",
@@ -146,31 +146,31 @@ class Test:
 
     def test_filtering_string_any(self, nornir: Nornir) -> None:
         f = F(some_string_to_test_any_all__any=["prefix", "other_prefix"])
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1", "dev3.group_2", "dev4.group_2"]
 
     def test_filtering_list_any(self, nornir: Nornir) -> None:
         f = F(nested_data__a_list__any=[1, 3])
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1", "dev2.group_1"]
 
     def test_filtering_list_all(self, nornir: Nornir) -> None:
         f = F(nested_data__a_list__all=[1, 2])
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == ["dev1.group_1"]
 
     def test_filter_wrong_attribute_for_type(self, nornir: Nornir) -> None:
         f = F(port__startswith="a")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == []
 
     def test_eq__on_not_existing_key(self, nornir: Nornir) -> None:
         f = F(not_existing__eq="test")
-        filtered = sorted(list((nornir.inventory.filter(f).hosts.keys())))
+        filtered = sorted(nornir.inventory.filter(f).hosts.keys())
 
         assert filtered == []
 

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -373,7 +373,7 @@ class Test:
         ]
 
     def test_filtering(self, inv: inventory.Inventory) -> None:
-        unfiltered = sorted(list(inv.hosts.keys()))
+        unfiltered = sorted(inv.hosts.keys())
         assert unfiltered == [
             "dev1.group_1",
             "dev2.group_1",
@@ -383,29 +383,27 @@ class Test:
             "dev6.group_3",
         ]
 
-        www = sorted(list(inv.filter(role="www").hosts.keys()))
+        www = sorted(inv.filter(role="www").hosts.keys())
         assert www == ["dev1.group_1", "dev3.group_2"]
 
-        www_site1 = sorted(list(inv.filter(role="www", site="site1").hosts.keys()))
+        www_site1 = sorted(inv.filter(role="www", site="site1").hosts.keys())
         assert www_site1 == ["dev1.group_1"]
 
-        www_site1 = sorted(list(inv.filter(role="www").filter(site="site1").hosts.keys()))
+        www_site1 = sorted(inv.filter(role="www").filter(site="site1").hosts.keys())
         assert www_site1 == ["dev1.group_1"]
 
     def test_filtering_func(self, inv: inventory.Inventory) -> None:
-        long_names = sorted(
-            list(inv.filter(filter_func=lambda x: len(x["my_var"]) > 20).hosts.keys())
-        )
+        long_names = sorted(inv.filter(filter_func=lambda x: len(x["my_var"]) > 20).hosts.keys())
         assert long_names == ["dev1.group_1", "dev4.group_2", "dev6.group_3"]
 
         def longer_than(dev: Host, length: int) -> bool:
             return len(dev["my_var"]) > length
 
-        long_names = sorted(list(inv.filter(filter_func=longer_than, length=20).hosts.keys()))
+        long_names = sorted(inv.filter(filter_func=longer_than, length=20).hosts.keys())
         assert long_names == ["dev1.group_1", "dev4.group_2", "dev6.group_3"]
 
     def test_filter_unique_keys(self, inv: inventory.Inventory) -> None:
-        filtered = sorted(list(inv.filter(www_server="nginx").hosts.keys()))
+        filtered = sorted(inv.filter(www_server="nginx").hosts.keys())
         assert filtered == ["dev1.group_1"]
 
     def test_var_resolution(self, inv: inventory.Inventory) -> None:

--- a/tests/core/test_tasks.py
+++ b/tests/core/test_tasks.py
@@ -123,15 +123,15 @@ class Test:
 
     def test_severity(self, nornir: Nornir) -> None:
         r = nornir.run(a_task_for_testing)
-        for host, result in r.items():
+        for result in r.values():
             assert result[0].severity_level == logging.INFO
 
         r = nornir.run(a_task_for_testing, severity_level=logging.WARN)
-        for host, result in r.items():
+        for result in r.values():
             assert result[0].severity_level == logging.WARN
 
         r = nornir.run(sub_task_for_testing, severity_level=logging.WARN)
-        for host, result in r.items():
+        for result in r.values():
             for sr in result:
                 assert sr.severity_level == logging.WARN
 
@@ -148,19 +148,19 @@ class Test:
                 assert result[1].severity_level == logging.DEBUG
 
         r = nornir.run(a_failed_task_for_testing)
-        for host, result in r.items():
+        for result in r.values():
             assert result[0].severity_level == logging.ERROR
         # Reset all failed host for next test
         nornir.data.reset_failed_hosts()
 
         r = nornir.run(a_failed_task_for_testing, severity_level=logging.WARN)
-        for host, result in r.items():
+        for result in r.values():
             assert result[0].severity_level == logging.ERROR
         # Reset all failed host for next test
         nornir.data.reset_failed_hosts()
 
         r = nornir.run(a_failed_task_for_testing_overrides_severity)
-        for host, result in r.items():
+        for result in r.values():
             assert result[0].severity_level == logging.CRITICAL
         # Reset all failed host for next test
         nornir.data.reset_failed_hosts()


### PR DESCRIPTION
Continues the ignore-list burn-down from #1068 and #1070. This PR takes `B007` and `C414` off the temporary ignore list in `pyproject.toml` and fixes the 36 violations they were suppressing.

All 36 are in `tests/` - `nornir/` is untouched, so there is no behaviour change to assess.

## `C414` - unnecessary `list()` call within `sorted()` (30 sites)

Purely mechanical: `sorted(list((inv.hosts.keys())))` -> `sorted(inv.hosts.keys())`.

| File | Sites |
|---|---|
| `tests/core/test_filter.py` | 23 |
| `tests/core/test_inventory.py` | 7 |

The `test_filter.py` lines also carried a redundant second set of parentheses, which went with the `list()`.

## `B007` - unused loop control variable (6 sites)

`tests/core/test_tasks.py::test_severity` had six loops of the form:

```python
for host, result in r.items():
    assert result[0].severity_level == logging.INFO
```

`host` is never read, so these now iterate `r.values()`. Renaming to `_host` would have silenced the rule equally, but `.values()` says what the loop actually needs. The one loop in that method that *does* use `host` (the `dev3.group_2` branch) is left as `.items()`.

## The typing holds without a `cast()`

Both fixes are type-safe on the existing strict mypy config, with no new annotations and no `cast()`:

- `Hosts` subclasses `dict[str, Host]`, so `keys()` is already a `KeysView[str]` and `sorted()` returns `list[str]` with or without the `list()` - the same type the assertions compare against.
- `AggregatedResult` subclasses `dict[str, MultiResult]`, so `values()` yields `ValuesView[MultiResult]` and `result[0]` still resolves to `Result`.

## Verification

```
ruff check .            # All checks passed!
ruff format --check .   # 46 files already formatted
mypy nornir tests       # Success: no issues found in 44 source files
pytest -q               # 118 passed
```
