### PR TITLE
Replace os.path and open() with pathlib equivalents

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,16 +14,16 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
+import pathlib
 import sys
 
 from nornir import __version__
 
-sys.path.insert(0, os.path.abspath("../"))
+sys.path.insert(0, str(pathlib.Path("../").resolve()))
 
 
 # -- General configuration ------------------------------------------------
-BASEPATH = os.path.abspath(os.path.dirname(__file__))
+BASEPATH = str(pathlib.Path(__file__).parent.resolve())
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #

--- a/docs/highlighter.py
+++ b/docs/highlighter.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from IPython.core.display import HTML
 from IPython.core.magic import register_line_magic
 from pygments import highlight
@@ -24,7 +26,7 @@ def highlight_file(filename: str) -> HTML:
 
     formatter = HtmlFormatter(style="default", cssclass="pygments", linenos=linenos)
 
-    with open(filename) as f:
+    with pathlib.Path(filename).open() as f:
         code = f.read()
 
     html_code = highlight(code, lexer, formatter)

--- a/nornir/core/configuration.py
+++ b/nornir/core/configuration.py
@@ -293,7 +293,7 @@ class Config:
         core = core or {}
         runner = runner or {}
         user_defined = user_defined or {}
-        with open(config_file, "r") as f:
+        with Path(config_file).open("r") as f:
             yml = ruamel.yaml.YAML(typ="safe")
             data = yml.load(f)
         return cls(

--- a/nornir/plugins/inventory/simple.py
+++ b/nornir/plugins/inventory/simple.py
@@ -95,7 +95,7 @@ class SimpleInventory:
         yml = ruamel.yaml.YAML(typ="safe")
 
         if self.defaults_file.exists():
-            with open(self.defaults_file, "r", encoding=self.encoding) as f:
+            with self.defaults_file.open("r", encoding=self.encoding) as f:
                 defaults_dict = yml.load(f) or {}
             if defaults_dict == {}:
                 logger.warning(
@@ -107,7 +107,7 @@ class SimpleInventory:
             defaults = Defaults()
 
         hosts = Hosts()
-        with open(self.host_file, "r", encoding=self.encoding) as f:
+        with self.host_file.open("r", encoding=self.encoding) as f:
             hosts_dict = yml.load(f) or {}
         if hosts_dict == {}:
             logger.warning(
@@ -120,7 +120,7 @@ class SimpleInventory:
 
         groups = Groups()
         if self.group_file.exists():
-            with open(self.group_file, "r", encoding=self.encoding) as f:
+            with self.group_file.open("r", encoding=self.encoding) as f:
                 groups_dict = yml.load(f) or {}
             if groups_dict == {}:
                 logger.warning(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,9 +168,6 @@ ignore = [
     "PLR6301", # Method `run` could be a function, class method, or static method
     "PLW1514", # `open` in text mode without explicit `encoding` argument
     "PLW1641", # Object does not implement `__hash__` method
-    "PTH100",  # `os.path.abspath()` should be replaced by `Path.resolve()`
-    "PTH120",  # `os.path.dirname()` should be replaced by `Path.parent`
-    "PTH123",  # `open()` should be replaced by `Path.open()`
     "PYI034",  # `__enter__` should return `Self`; requires Python 3.11+ (or typing_extensions)
     "RSE102",  # Unnecessary parentheses on raised exception
     "RUF001",  # String contains ambiguous `–` (EN DASH). Did you mean `-` (HYPHEN-MINUS)?
@@ -261,8 +258,6 @@ max-returns = 11
     "PLC1901", # Can be simplified as an empty string is falsey
     "PLR0904", # Too many public methods
     "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
-    "PTH118",  # `os.path.join()` should be replaced by `Path` with `/` operator
-    "PTH120",  # `os.path.dirname()` should be replaced by `Path.parent`
     "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-import os
+import pathlib
 from typing import Any, TypeVar
 
 import pytest
@@ -24,7 +24,7 @@ global_data = GlobalState(dry_run=True)
 
 
 def inventory_from_yaml() -> Inventory:
-    dir_path = os.path.dirname(os.path.realpath(__file__))
+    data_path = pathlib.Path(__file__).resolve().parent / "inventory_data"
     yml = ruamel.yaml.YAML(typ="safe")
 
     def get_connection_options(data: dict[str, Any]) -> dict[str, ConnectionOptions]:
@@ -41,8 +41,8 @@ def inventory_from_yaml() -> Inventory:
         return cp
 
     def get_defaults() -> Defaults:
-        defaults_file = f"{dir_path}/inventory_data/defaults.yaml"
-        with open(defaults_file, "r") as f:
+        defaults_file = data_path / "defaults.yaml"
+        with defaults_file.open("r") as f:
             defaults_dict = yml.load(f)
 
             return Defaults(
@@ -75,20 +75,20 @@ def inventory_from_yaml() -> Inventory:
             connection_options=get_connection_options(data.get("connection_options", {})),
         )
 
-    host_file = f"{dir_path}/inventory_data/hosts.yaml"
-    group_file = f"{dir_path}/inventory_data/groups.yaml"
+    host_file = data_path / "hosts.yaml"
+    group_file = data_path / "groups.yaml"
 
     defaults = get_defaults()
 
     hosts = Hosts()
-    with open(host_file, "r") as f:
+    with host_file.open("r") as f:
         hosts_dict = yml.load(f)
 
     for n, h in hosts_dict.items():
         hosts[n] = get_inventory_element(Host, h, n, defaults)
 
     groups = Groups()
-    with open(group_file, "r") as f:
+    with group_file.open("r") as f:
         groups_dict = yml.load(f)
 
     for n, g in groups_dict.items():

--- a/tests/core/test_InitNornir.py
+++ b/tests/core/test_InitNornir.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 import os
+import pathlib
 from typing import Any
 
 import pytest
@@ -13,7 +14,7 @@ from nornir.core.plugins.inventory import (
     TransformFunctionRegister,
 )
 
-dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_InitNornir")
+dir_path = pathlib.Path(__file__).resolve().parent / "test_InitNornir"
 
 LOGGING_DICT = {
     "version": 1,
@@ -80,7 +81,7 @@ class Test:
         assert len(nr.inventory.groups)
 
     def test_InitNornir_file(self) -> None:
-        nr = InitNornir(config_file=os.path.join(dir_path, "a_config.yaml"))
+        nr = InitNornir(config_file=str(dir_path / "a_config.yaml"))
         assert not nr.data.dry_run
         assert len(nr.inventory.hosts)
         assert len(nr.inventory.groups)
@@ -103,14 +104,14 @@ class Test:
 
     def test_InitNornir_override_partial_section(self) -> None:
         nr = InitNornir(
-            config_file=os.path.join(dir_path, "a_config.yaml"),
+            config_file=str(dir_path / "a_config.yaml"),
             core={"raise_on_error": True},
         )
         assert nr.config.core.raise_on_error
 
     def test_InitNornir_combined(self) -> None:
         nr = InitNornir(
-            config_file=os.path.join(dir_path, "a_config.yaml"),
+            config_file=str(dir_path / "a_config.yaml"),
             core={"raise_on_error": True},
         )
         assert not nr.data.dry_run
@@ -120,7 +121,7 @@ class Test:
 
     def test_InitNornir_different_transform_function_by_string(self) -> None:
         nr = InitNornir(
-            config_file=os.path.join(dir_path, "a_config.yaml"),
+            config_file=str(dir_path / "a_config.yaml"),
             inventory={
                 "plugin": "inventory-test",
                 "transform_function": "transform_func",
@@ -135,7 +136,7 @@ class Test:
 
     def test_InitNornir_different_transform_function_by_string_with_options(self) -> None:
         nr = InitNornir(
-            config_file=os.path.join(dir_path, "a_config.yaml"),
+            config_file=str(dir_path / "a_config.yaml"),
             inventory={
                 "plugin": "inventory-test",
                 "transform_function": "transform_func_with_options",
@@ -152,7 +153,7 @@ class Test:
     def test_InitNornir_different_transform_function_by_string_with_bad_options(self) -> None:
         with pytest.raises(TypeError):
             InitNornir(
-                config_file=os.path.join(dir_path, "a_config.yaml"),
+                config_file=str(dir_path / "a_config.yaml"),
                 inventory={
                     "plugin": "inventory-test",
                     "transform_function": "transform_func_with_options",
@@ -189,7 +190,7 @@ class TestLogging:
     def test_InitNornir_logging_defaults(self) -> None:
         self.cleanup()
         InitNornir(
-            config_file=os.path.join(dir_path, "a_config.yaml"),
+            config_file=str(dir_path / "a_config.yaml"),
         )
         nornir_logger = logging.getLogger("nornir")
 
@@ -200,7 +201,7 @@ class TestLogging:
     def test_InitNornir_logging_to_console(self) -> None:
         self.cleanup()
         InitNornir(
-            config_file=os.path.join(dir_path, "a_config.yaml"),
+            config_file=str(dir_path / "a_config.yaml"),
             logging={"to_console": True},
         )
         nornir_logger = logging.getLogger("nornir")
@@ -213,7 +214,7 @@ class TestLogging:
     def test_InitNornir_logging_disabled(self) -> None:
         self.cleanup()
         InitNornir(
-            config_file=os.path.join(dir_path, "a_config.yaml"),
+            config_file=str(dir_path / "a_config.yaml"),
             logging={"enabled": False},
         )
         nornir_logger = logging.getLogger("nornir")
@@ -224,7 +225,7 @@ class TestLogging:
         self.cleanup()
         logging.basicConfig()
         with pytest.warns(ConflictingConfigurationWarning):
-            InitNornir(config_file=os.path.join(dir_path, "a_config.yaml"))
+            InitNornir(config_file=str(dir_path / "a_config.yaml"))
         nornir_logger = logging.getLogger("nornir")
 
         assert logging.getLogger().hasHandlers()
@@ -235,7 +236,7 @@ class TestLogging:
         self.cleanup()
         logging.config.dictConfig(LOGGING_DICT)
         with pytest.warns(ConflictingConfigurationWarning):
-            InitNornir(config_file=os.path.join(dir_path, "a_config.yaml"))
+            InitNornir(config_file=str(dir_path / "a_config.yaml"))
 
         nornir_logger = logging.getLogger("nornir")
         root_logger = logging.getLogger()

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from nornir.core.configuration import Config
 
-dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_configuration")
+dir_path = Path(__file__).resolve().parent / "test_configuration"
 
 
 DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)12s - %(levelname)8s - %(funcName)10s() - %(message)s"
@@ -86,7 +86,7 @@ class Test:
 
     def test_configuration_file_override_argument(self) -> None:
         config = Config.from_file(
-            os.path.join(dir_path, "config.yaml"),
+            str(dir_path / "config.yaml"),
             core={"raise_on_error": True},
         )
         assert config.core.raise_on_error
@@ -106,19 +106,17 @@ class Test:
         assert not config.core.raise_on_error
 
     def test_get_user_defined_from_file(self) -> None:
-        config = Config.from_file(os.path.join(dir_path, "config.yaml"))
+        config = Config.from_file(str(dir_path / "config.yaml"))
         assert config.user_defined["asd"] == "qwe"
 
     def test_order_of_resolution_config_higher_than_env(self) -> None:
         os.environ["NORNIR_CORE_RAISE_ON_ERROR"] = "1"
-        config = Config.from_file(os.path.join(dir_path, "config.yaml"))
+        config = Config.from_file(str(dir_path / "config.yaml"))
         os.environ.pop("NORNIR_CORE_RAISE_ON_ERROR")
         assert config.core.raise_on_error is False
 
     def test_order_of_resolution_code_is_higher_than_env(self) -> None:
         os.environ["NORNIR_CORE_RAISE_ON_ERROR"] = "0"
-        config = Config.from_file(
-            os.path.join(dir_path, "config.yaml"), core={"raise_on_error": True}
-        )
+        config = Config.from_file(str(dir_path / "config.yaml"), core={"raise_on_error": True})
         os.environ.pop("NORNIR_CORE_RAISE_ON_ERROR")
         assert config.core.raise_on_error is True

--- a/tests/core/test_inventory.py
+++ b/tests/core/test_inventory.py
@@ -1,4 +1,4 @@
-import os
+import pathlib
 
 import pytest
 import ruamel.yaml
@@ -7,12 +7,12 @@ from nornir.core import inventory
 from nornir.core.inventory import Host
 
 yaml = ruamel.yaml.YAML(typ="safe")
-dir_path = os.path.dirname(os.path.realpath(__file__))
-with open(f"{dir_path}/../inventory_data/hosts.yaml") as f:
+data_path = pathlib.Path(__file__).resolve().parent.parent / "inventory_data"
+with (data_path / "hosts.yaml").open() as f:
     hosts = yaml.load(f)
-with open(f"{dir_path}/../inventory_data/groups.yaml") as f:
+with (data_path / "groups.yaml").open() as f:
     groups = yaml.load(f)
-with open(f"{dir_path}/../inventory_data/defaults.yaml") as f:
+with (data_path / "defaults.yaml").open() as f:
     defaults = yaml.load(f)
 inv_dict = {"hosts": hosts, "groups": groups, "defaults": defaults}
 

--- a/tests/plugins/inventory/test_simple_inventory.py
+++ b/tests/plugins/inventory/test_simple_inventory.py
@@ -1,15 +1,15 @@
-import os
+import pathlib
 
 from nornir.plugins.inventory import SimpleInventory
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
+data_path = pathlib.Path(__file__).resolve().parent / "data"
 
 
 class Test:
     def test(self) -> None:
-        host_file = f"{dir_path}/data/hosts.yaml"
-        group_file = f"{dir_path}/data/groups.yaml"
-        defaults_file = f"{dir_path}/data/defaults.yaml"
+        host_file = str(data_path / "hosts.yaml")
+        group_file = str(data_path / "groups.yaml")
+        defaults_file = str(data_path / "defaults.yaml")
 
         inv = SimpleInventory(host_file, group_file, defaults_file).load()
         assert inv.dict() == {
@@ -234,9 +234,9 @@ class Test:
 
     def test_simple_inventory_empty(self) -> None:
         """Verify completely empty groups.yaml and defaults.yaml doesn't generate exception."""
-        host_file = f"{dir_path}/data/hosts-nogroups.yaml"
-        group_file = f"{dir_path}/data/groups-empty.yaml"
-        defaults_file = f"{dir_path}/data/defaults-empty.yaml"
+        host_file = str(data_path / "hosts-nogroups.yaml")
+        group_file = str(data_path / "groups-empty.yaml")
+        defaults_file = str(data_path / "defaults-empty.yaml")
 
         inv = SimpleInventory(host_file, group_file, defaults_file).load()
         assert len(inv.hosts) == 1
@@ -245,9 +245,9 @@ class Test:
 
     def test_simple_inventory_empty_hosts(self) -> None:
         """Verify completely empty hosts.yaml doesn't generate exception."""
-        host_file = f"{dir_path}/data/hosts-empty.yaml"
-        group_file = f"{dir_path}/data/groups-empty.yaml"
-        defaults_file = f"{dir_path}/data/defaults-empty.yaml"
+        host_file = str(data_path / "hosts-empty.yaml")
+        group_file = str(data_path / "groups-empty.yaml")
+        defaults_file = str(data_path / "defaults-empty.yaml")
 
         inv = SimpleInventory(host_file, group_file, defaults_file).load()
         assert inv.hosts == {}

--- a/tests/wrapper.py
+++ b/tests/wrapper.py
@@ -1,3 +1,4 @@
+import pathlib
 import sys
 from collections.abc import Callable
 from io import StringIO
@@ -33,17 +34,17 @@ def wrap_cli_test(output: str, save_output: bool = False) -> Callable[[Callable[
         output_file = output
 
         if save_output:
-            with open("{}.stdout".format(output_file), "w+") as f:
+            with pathlib.Path("{}.stdout".format(output_file)).open("w+") as f:
                 f.write(stdout.getvalue())
-            with open("{}.stderr".format(output_file), "w+") as f:
+            with pathlib.Path("{}.stderr".format(output_file)).open("w+") as f:
                 f.write(stderr.getvalue())
 
-        with open("{}.stdout".format(output_file), "r") as f:
+        with pathlib.Path("{}.stdout".format(output_file)).open("r") as f:
             screen_output = stdout.getvalue()
             reference_output = f.read()
             assert screen_output == reference_output
 
-        with open("{}.stderr".format(output_file), "r") as f:
+        with pathlib.Path("{}.stderr".format(output_file)).open("r") as f:
             screen_output = stderr.getvalue()
             reference_output = f.read()
             assert screen_output == reference_output


### PR DESCRIPTION
## Summary

Continues the incremental ruff rollout by clearing the flake8-use-pathlib backlog.
PTH100, PTH118, PTH120 and PTH123 are no longer ignored, so code that reaches for
`os.path` or a bare `open()` is now caught by the linter instead of by review.

## Key Changes

- The PTH entries are dropped from the ignore lists in `pyproject.toml` (PTH100,
  PTH120 and PTH123 globally; PTH118 and PTH120 for `tests/**.py`) and the 25
  violations they were suppressing are fixed.
- `SimpleInventory.load()` no longer re-wraps its own attributes in `pathlib.Path()`.
  `host_file`, `group_file` and `defaults_file` are already `Path` objects after
  `expanduser()`, so they are opened directly.
- Test and docs helpers derive fixture paths from `Path(__file__).resolve().parent`
  rather than `os.path.dirname(os.path.realpath(__file__))`.
- No public signature changes: everything passed to `Config.from_file`, `InitNornir`
  and `SimpleInventory` is still a `str`, so behaviour is unchanged.

## Test Plan

- `make ruff` - clean (was 25 violations)
- `uv run ruff format --check .` - clean
- `make mypy` - no issues found in 44 source files
- `make pytest` - 118 passed
- `make nbval` - could not be verified locally. The Jupyter kernel fails to start in
  my environment (`RuntimeError: Kernel didn't respond in 60 seconds`) regardless of
  this branch, so no notebook cell executes. Worth watching in CI. The only
  notebook-relevant change is `docs/highlighter.py`, where `open(filename)` became
  `Path(filename).open()`.