### PR TITLE
Re-enable the FURB101 and PLW1514 ruff rules

### DIFF
--- a/docs/highlighter.py
+++ b/docs/highlighter.py
@@ -26,8 +26,7 @@ def highlight_file(filename: str) -> HTML:
 
     formatter = HtmlFormatter(style="default", cssclass="pygments", linenos=linenos)
 
-    with pathlib.Path(filename).open() as f:
-        code = f.read()
+    code = pathlib.Path(filename).read_text(encoding="utf-8")
 
     html_code = highlight(code, lexer, formatter)
     css = formatter.get_style_defs()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,11 +197,6 @@ max-returns = 11
     "ERA001", # Commented out code, used to provide examples for Sphinx docs
 ]
 
-"docs/highlighter.py" = [
-    "FURB101", # `open` and `read` should be replaced by `Path(filename).read_text()`
-    "PLW1514", # `open` in text mode without explicit `encoding` argument
-]
-
 "nornir/**.py" = [
 ##################################################################################################
 # The ignored rules below should be removed once the code has been updated, they are included    #
@@ -239,13 +234,11 @@ max-returns = 11
 ##################################################################################################
     "ARG001",  # Unused function argument
     "DTZ005",  # `datetime.datetime.now()` called without a `tz` argument
-    "FURB101", # `open` and `read` should be replaced by `Path(filename).read_text()`
     "LOG009",  # Use of undocumented `logging.WARN` constant
     "N999",    # Invalid module name
     "PLC1901", # Can be simplified as an empty string is falsey
     "PLR0904", # Too many public methods
     "PLR2004", # Magic value used in comparison, consider replacing with a constant variable
-    "PLW1514", # `open` in text mode without explicit `encoding` argument
     "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
     "UP032",   # Use f-string instead of `format` call
 ]

--- a/tests/wrapper.py
+++ b/tests/wrapper.py
@@ -33,22 +33,14 @@ def wrap_cli_test(output: str, save_output: bool = False) -> Callable[[Callable[
         sys.stdout = backup_stdout
         sys.stderr = backup_stderr
 
-        output_file = output
+        stdout_file = pathlib.Path(f"{output}.stdout")
+        stderr_file = pathlib.Path(f"{output}.stderr")
 
         if save_output:
-            with pathlib.Path("{}.stdout".format(output_file)).open("w+") as f:
-                f.write(stdout.getvalue())
-            with pathlib.Path("{}.stderr".format(output_file)).open("w+") as f:
-                f.write(stderr.getvalue())
+            stdout_file.write_text(stdout.getvalue(), encoding="utf-8")
+            stderr_file.write_text(stderr.getvalue(), encoding="utf-8")
 
-        with pathlib.Path("{}.stdout".format(output_file)).open("r") as f:
-            screen_output = stdout.getvalue()
-            reference_output = f.read()
-            assert screen_output == reference_output
-
-        with pathlib.Path("{}.stderr".format(output_file)).open("r") as f:
-            screen_output = stderr.getvalue()
-            reference_output = f.read()
-            assert screen_output == reference_output
+        assert stdout.getvalue() == stdout_file.read_text(encoding="utf-8")
+        assert stderr.getvalue() == stderr_file.read_text(encoding="utf-8")
 
     return run_test


### PR DESCRIPTION
## Summary

Retires two more of the temporary ruff suppressions carried since the "enable all rules" sweep, fixing the underlying code instead of extending the ignore list. Files are now read and written with an explicit `utf-8` encoding, so docs rendering and CLI test comparisons no longer depend on the ambient locale of whoever runs them.

## Key Changes

- `FURB101` and `PLW1514` dropped from the `docs/highlighter.py` and `tests/**.py` ignore lists in `pyproject.toml`; the `docs/highlighter.py` per-file-ignore block is now empty and removed entirely.
- Both call sites converted from manual `open()`/`read()`/`write()` to `Path.read_text()` / `Path.write_text()` with an explicit encoding.
- `tests/wrapper.py` rebuilt the same two output paths four separate times; these are hoisted into locals so the reads and writes share one definition, taking the block from 18 lines to 9.

## Related Context

Continues the rule-by-rule cleanup started in "Enable all ruff rules and ignore new violations", following the same pattern as "Re-enable the B007 and C414 ruff rules" and "Re-enable fourteen pydocstyle and pydoclint ruff rules".

## Notes for reviewers

- `tests/wrapper.py` now uses f-strings rather than `"{}".format(...)`. `UP032` is still suppressed for `tests/**.py`, so this reduces that rule's footprint as a side effect without removing it from the ignore list.
- `wrap_cli_test` currently has no callers in the repo; it is kept deliberately as scaffolding used when regenerating test output.

## Test Plan

- `make ruff` - clean, zero violations.
- `make mypy` - no issues in 44 source files.
- `make pytest` - 118 passed.
- `make nbval` - fails locally on Jupyter kernel startup ("Kernel didn't respond in 60 seconds") at cell setup. This reproduces identically with the branch changes stashed on unmodified `main`, so it is environmental rather than introduced here. Relying on CI for the real signal.
