### PR TITLE
refactor: re-enable SIM108, SIM110 and scope RUF012

### DIFF
--- a/nornir/core/inventory.py
+++ b/nornir/core/inventory.py
@@ -345,16 +345,10 @@ class Host(InventoryElement):
         return self._has_parent_group_by_object(group)
 
     def _has_parent_group_by_name(self, group: str) -> bool:
-        for g in self.groups:
-            if g.name == group or g.has_parent_group(group):
-                return True
-        return False
+        return any(g.name == group or g.has_parent_group(group) for g in self.groups)
 
     def _has_parent_group_by_object(self, group: Group) -> bool:
-        for g in self.groups:
-            if g is group or g.has_parent_group(group):
-                return True
-        return False
+        return any(g is group or g.has_parent_group(group) for g in self.groups)
 
     def __getitem__(self, item: str) -> Any:
         try:

--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -62,10 +62,7 @@ def InitNornir(
     """
     ConnectionPluginRegister.auto_register()
 
-    if config_file:
-        config = Config.from_file(config_file, **kwargs)
-    else:
-        config = Config.from_dict(**kwargs)
+    config = Config.from_file(config_file, **kwargs) if config_file else Config.from_dict(**kwargs)
 
     data = GlobalState(dry_run=dry_run)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,12 +160,9 @@ ignore = [
     "PYI034",  # `__enter__` should return `Self`; requires Python 3.11+ (or typing_extensions)
     "RSE102",  # Unnecessary parentheses on raised exception
     "RUF001",  # String contains ambiguous `–` (EN DASH). Did you mean `-` (HYPHEN-MINUS)?
-    "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF067",  # `__init__` module should only contain docstrings and re-exports
     "S701",    # By default, jinja2 sets `autoescape` to `False`. Consider using `autoescape=True` or the `select_autoescape` function to mitigate XSS vulnerabilities.
     "SLF001",  # Private member accessed
-    "SIM108",  # Use ternary operator `config = Config.from_file(config_file, **kwargs) if config_file else Config.from_dict(**kwargs)` instead of `if`-`else`-block
-    "SIM110",  # Use `return any(g.name == group or g.has_parent_group(group) for g in self.groups)` instead of `for` loop
     "TC001",   # Move application import into a type-checking block (first-party re-export restructuring is out of scope for the PEP 585/604 cleanup)
     "TRY002",  # Create your own exception
     "TRY003",  # Avoid specifying long messages outside the exception class
@@ -216,6 +213,15 @@ max-returns = 11
 
 "nornir/core/configuration.py" = [
     "A002",    # Argument `format` / `help` is shadowing a Python builtin
+]
+
+"nornir/core/plugins/register.py" = [
+##################################################################################################
+# The ignored rules below should be removed once the code has been updated, they are included    #
+# like this so that we can reactivate them one by one. Alternatively ignored after further       #
+# investigation if they are deemed to not make sense.                                            #
+##################################################################################################
+    "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar` (every fix changes behaviour)
 ]
 
 "nornir/core/task.py" = [


### PR DESCRIPTION
Continues the work of reactivating ruff rules one at a time. Removes `SIM108`, `SIM110` and `RUF012` from the global ignore list in `pyproject.toml`.

No behaviour change is intended anywhere in this PR.

### SIM110

The two `_has_parent_group_by_*` helpers in `nornir/core/inventory.py` become `any()` generator expressions. Same short-circuit semantics as the loops they replace.

### SIM108

The `config_file` branch in `InitNornir` becomes a ternary.

### RUF012

`PluginRegister.available` is left exactly as it is and the rule moves to a per-file ignore, because both available fixes change behaviour:

- **Moving the dict into `__init__`** would isolate the registers from each other. Today all four share the one class-level dict until `deregister_all()` shadows it with an instance attribute, so `ConnectionPluginRegister.available is InventoryPluginRegister.available` is `True`.
- **`ClassVar`** does not typecheck. mypy reports `ClassVar cannot contain type variables` and `Cannot assign to class variable "available" via instance`, the latter breaking `deregister_all()`.

The shared dict is arguably a latent bug: an inventory plugin and a connection plugin registered under the same name would collide and raise `PluginAlreadyRegistered`. That is a behaviour fix rather than a lint fix, so it is left for a separate change and the ignore carries the usual "remove once the code has been updated" banner.

### Verification

`ruff check .`, `ruff format --check .` and `mypy` are clean, and the 118 tests pass.
