### PR TITLE
Expose InitNornir configuration parameters explicitly

### DIFF
--- a/nornir/init_nornir.py
+++ b/nornir/init_nornir.py
@@ -43,18 +43,25 @@ def load_runner(
 def InitNornir(
     config_file: str = "",
     dry_run: bool = False,
-    **kwargs: Any,
+    *,
+    inventory: dict[str, Any] | None = None,
+    ssh: dict[str, Any] | None = None,
+    logging: dict[str, Any] | None = None,
+    core: dict[str, Any] | None = None,
+    runner: dict[str, Any] | None = None,
+    user_defined: dict[str, Any] | None = None,
 ) -> Nornir:
     """Instantiate and configure a Nornir object.
 
     Arguments:
         config_file(str): Path to the configuration file (optional)
         dry_run(bool): Whether to simulate changes or not
-        configure_logging: Whether to configure logging or not. This argument is being
-            deprecated. Please use logging.enabled parameter in the configuration
-            instead.
-        **kwargs: Extra information to pass to the
-            :obj:`nornir.core.configuration.Config` object
+        inventory(dict): Inventory configuration section
+        ssh(dict): SSH configuration section
+        logging(dict): Logging configuration section
+        core(dict): Core configuration section
+        runner(dict): Runner configuration section
+        user_defined(dict): User-defined configuration section
 
     Returns:
         :obj:`nornir.core.Nornir`: fully instantiated and configured
@@ -62,7 +69,25 @@ def InitNornir(
     """
     ConnectionPluginRegister.auto_register()
 
-    config = Config.from_file(config_file, **kwargs) if config_file else Config.from_dict(**kwargs)
+    if config_file:
+        config = Config.from_file(
+            config_file,
+            inventory=inventory,
+            ssh=ssh,
+            logging=logging,
+            core=core,
+            runner=runner,
+            user_defined=user_defined,
+        )
+    else:
+        config = Config.from_dict(
+            inventory=inventory,
+            ssh=ssh,
+            logging=logging,
+            core=core,
+            runner=runner,
+            user_defined=user_defined,
+        )
 
     data = GlobalState(dry_run=dry_run)
 

--- a/tests/core/test_InitNornir.py
+++ b/tests/core/test_InitNornir.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import logging.config
 import os
@@ -64,6 +65,42 @@ TransformFunctionRegister.register("transform_func_with_options", transform_func
 
 
 class Test:
+    def test_InitNornir_exposes_config_sections_as_keyword_only(self) -> None:
+        parameters = inspect.signature(InitNornir).parameters
+        config_sections = {"inventory", "ssh", "logging", "core", "runner", "user_defined"}
+
+        assert set(parameters) == {"config_file", "dry_run", *config_sections}
+        for name in config_sections:
+            assert parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+
+    @pytest.mark.parametrize(
+        ("config_file", "raise_on_error"),
+        [
+            ("", True),
+            (str(dir_path / "a_config.yaml"), False),
+        ],
+    )
+    def test_InitNornir_forwards_config_sections(
+        self, config_file: str, raise_on_error: bool
+    ) -> None:
+        ssh_config_file = str(dir_path / "ssh_config")
+        nr = InitNornir(
+            config_file=config_file,
+            inventory={"plugin": "inventory-test"},
+            ssh={"config_file": ssh_config_file},
+            logging={"enabled": False},
+            core={"raise_on_error": raise_on_error},
+            runner={"plugin": "serial"},
+            user_defined={"my_opt": True},
+        )
+
+        assert nr.config.inventory.plugin == "inventory-test"
+        assert nr.config.ssh.config_file == ssh_config_file
+        assert not nr.config.logging.enabled
+        assert nr.config.core.raise_on_error is raise_on_error
+        assert nr.config.runner.plugin == "serial"
+        assert nr.config.user_defined == {"my_opt": True}
+
     def test_InitNornir_bare(self) -> None:
         os.chdir("tests/inventory_data/")
         nr = InitNornir()


### PR DESCRIPTION
Closes #1079

Replaces `InitNornir()`'s `**kwargs` with the six configuration sections already accepted by `Config`. This makes the supported arguments visible to users, IDEs and type checkers while preserving existing keyword-based calls.

I also updated the docstring and added tests for the public signature and configuration forwarding, both with and without a config file.

Tests: `make tests`